### PR TITLE
ISOTimeFormat implementation

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -35,6 +35,8 @@ export default function installYamcsPlugin(configuration) {
 
         //TODO: Validate provided configuration
 
+        openmct.install(openmct.plugins.ISOTimeFormat());
+
         const historicalProvider = new YamcsHistoricalTelemetryProvider(
             configuration.yamcsHistoricalEndpoint,
             configuration.yamcsInstance);

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -154,10 +154,10 @@ export default class YamcsObjectProvider {
                         }
                     },
                     {
-                        key: 'utc',
+                        key: 'iso',
                         source: 'timestamp',
                         name: 'Timestamp',
-                        format: 'utc',
+                        format: 'iso',
                         hints: {
                             domain: 1
                         }


### PR DESCRIPTION
To utilize the new ISOTimeFormat from OpenMCT installed new format plugin, then object metadata format from 'utc' to 'iso'.

Closes #9 

## Author Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? N/A
Command line build passes? N/A
Changes have been smoke-tested? Locally (need to test on server)
Testing instructions included? Yes