### PR TITLE
Revert timestamp key back to utc

### DIFF
--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -157,7 +157,7 @@ export default class YamcsObjectProvider {
                         key: 'utc',
                         source: 'timestamp',
                         name: 'Timestamp',
-                        format: 'utc',
+                        format: 'iso',
                         hints: {
                             domain: 1
                         }

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -154,10 +154,10 @@ export default class YamcsObjectProvider {
                         }
                     },
                     {
-                        key: 'iso',
+                        key: 'utc',
                         source: 'timestamp',
                         name: 'Timestamp',
-                        format: 'iso',
+                        format: 'utc',
                         hints: {
                             domain: 1
                         }


### PR DESCRIPTION
The metadata timestamp key needs to be utc instead of iso to prevent breaking errors.

closes #12 

## Author Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? Check that errors are gone 👍 
Command line build passes? N/A
Changes have been smoke-tested? On Hulk (TBD)
Testing instructions included? Yes