### PR TITLE
Temporary limit cap for historical requests

### DIFF
--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -42,6 +42,11 @@ export default class YamcsHistoricalTelemetryProvider {
     }
 
     getHistory(id, start, end, size=300) {
+        // cap size at 1000, temporarily to prevent errors
+        if (size > 1000) {
+            size = 1000;
+        }
+
         let url = this.url + 'api/archive/' + this.instance + '/parameters' + idToQualifiedName(id);
         url += '?start=' + (new Date(start).toISOString());
         url += '&stop=' + (new Date(end).toISOString());

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -60,6 +60,11 @@ export default class YamcsHistoricalTelemetryProvider {
     }
 
     getSampleHistory(id, start, end, size=300) {
+        // cap size at 1000, temporarily to prevent errors
+        if (size > 1000) {
+            size = 1000;
+        }
+
         let url = this.url + 'api/archive/' + this.instance + '/parameters' + idToQualifiedName(id);
         url += '/samples';
         url += '?start=' + (new Date(start).toISOString());


### PR DESCRIPTION
Temporarily limit requests to 1000 to prevent errors. Long term, we'll figure out a better way to handle this situation.

closes #18 

## Author Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? N/A
Command line build passes? Yes
Changes have been smoke-tested? Will test on server
Testing instructions included? Yes