### PR TITLE
Imagery endpoint check

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -39,7 +39,8 @@ export default function installYamcsPlugin(configuration) {
 
         const historicalProvider = new YamcsHistoricalTelemetryProvider(
             configuration.yamcsHistoricalEndpoint,
-            configuration.yamcsInstance);
+            configuration.yamcsInstance,
+            openmct);
         openmct.telemetry.addProvider(historicalProvider);
 
         const realtimeProvider = new YamcsRealtimeTelemetryProvider(

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -36,6 +36,7 @@ export default function installYamcsPlugin(configuration) {
         //TODO: Validate provided configuration
 
         openmct.install(openmct.plugins.ISOTimeFormat());
+        openmct.install(openmct.plugins.NonEditableFolder());
 
         const historicalProvider = new YamcsHistoricalTelemetryProvider(
             openmct,

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -38,9 +38,9 @@ export default function installYamcsPlugin(configuration) {
         openmct.install(openmct.plugins.ISOTimeFormat());
 
         const historicalProvider = new YamcsHistoricalTelemetryProvider(
+            openmct,
             configuration.yamcsHistoricalEndpoint,
-            configuration.yamcsInstance,
-            openmct);
+            configuration.yamcsInstance);
         openmct.telemetry.addProvider(historicalProvider);
 
         const realtimeProvider = new YamcsRealtimeTelemetryProvider(

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -61,7 +61,7 @@ export default class YamcsHistoricalTelemetryProvider {
         let convertHistory = (res) => this.convertPointHistory(id, res);
         if (strategy && strategy.toLowerCase() === 'latest') {
             size = 1;
-            order = 'desc'
+            order = 'desc';
         } else if (strategy && strategy.toLowerCase() === 'minmax' && !isImagery) {
             url += '/samples';
             sizeParam = 'count';
@@ -89,10 +89,10 @@ export default class YamcsHistoricalTelemetryProvider {
                 id: parameter.id.name,
                 timestamp: parameter.generationTimeUTC,
                 value: getValue(parameter.engValue)
-            }
-            addLimitInformation(parameter, point)
-            values.push(point)
-        })
+            };
+            addLimitInformation(parameter, point);
+            values.push(point);
+        });
 
         return values;
     }

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -27,7 +27,7 @@ import {
 } from '../utils.js';
 
 export default class YamcsHistoricalTelemetryProvider {
-    constructor(url, instance, openmct) {
+    constructor(openmct, url, instance) {
         this.url = url;
         this.instance = instance;
         this.openmct = openmct;

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -39,7 +39,7 @@ export default class YamcsHistoricalTelemetryProvider {
 
     request(domainObject, options) {
         let metadata = this.openmct.telemetry.getMetadata(domainObject);
-        let isImagery = metadata.valuesForHints(['range']).length !== 0;
+        let isImagery = metadata.valuesForHints(['image']).length !== 0;
 
         return this.getHistory(domainObject.identifier.key,
             options.start,

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -40,48 +40,37 @@ export default class YamcsHistoricalTelemetryProvider {
         return this.getHistory(domainObject.identifier.key,
             options.start,
             options.end,
-            options.size);
+            options.size,
+            options.strategy);
     }
 
-    getHistory(id, start, end, size=300) {
+    getHistory(id, start, end, size=300, strategy) {
         // cap size at 1000, temporarily to prevent errors
         if (size > 1000) {
             size = 1000;
         }
 
         let url = this.url + 'api/archive/' + this.instance + '/parameters' + idToQualifiedName(id);
-        url += '?start=' + (new Date(start).toISOString());
-        url += '&stop=' + (new Date(end).toISOString());
-        url += '&limit=' + size;
-        url += "&order=asc";
-
-        return fetch(encodeURI(url))
-            .then(res => {return res.json();})
-            .then(res => {
-                if (!(res.continuationToken)) {
-                    return this.convertPointHistory(id, res);
-                } else {
-                    return this.getSampleHistory(id, start, end, size);
-                }
-            });
-    }
-
-    getSampleHistory(id, start, end, size=300) {
-        // cap size at 1000, temporarily to prevent errors
-        if (size > 1000) {
-            size = 1000;
+        let order = 'asc';
+        let sizeParam = 'limit';
+        let convertHistory = (res) => this.convertPointHistory(id, res);
+        if (strategy && strategy.toLowerCase() === 'latest') {
+            size = 1;
+            order = 'desc'
+        } else if (strategy && strategy.toLowerCase() === 'minmax') {
+            url += '/samples';
+            sizeParam = 'count';
+            convertHistory = (res) => this.convertSampleHistory(id, res);
         }
 
-        let url = this.url + 'api/archive/' + this.instance + '/parameters' + idToQualifiedName(id);
-        url += '/samples';
         url += '?start=' + (new Date(start).toISOString());
         url += '&stop=' + (new Date(end).toISOString());
-        url += '&count=' + size;
-        url += "&order=asc";
+        url += `&${sizeParam}=${size}`;
+        url += `&order=${order}`;
 
         return fetch(encodeURI(url))
-            .then(res => {return res.json();})
-            .then(res => {return this.convertSampleHistory(id, res);});
+            .then(res => res.json())
+            .then(convertHistory);
     }
 
     convertPointHistory(id, results) {
@@ -131,5 +120,4 @@ export default class YamcsHistoricalTelemetryProvider {
 
         return values;
     }
-
 }

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -76,25 +76,25 @@ export default class YamcsObjectProvider {
 
     fetchTelemetryDictionary() {
         if(this.dictionaryPromise === undefined) {
-            let url = this.getMdbUrl('space-systems')
+            let url = this.getMdbUrl('space-systems');
             this.dictionaryPromise = accumulateResults(url, 'spaceSystems', []).then(spaceSystems => {
                 return this.fetchMdbApi('parameters?details=yes&limit=1000')
                     .then(parameters => {
                         /* Sort the space systems by name, so that the
                            children of the root object are in sorted order. */
                         spaceSystems.sort((a, b) => {
-                            a.name.localeCompare(b.name)
-                        })
+                            a.name.localeCompare(b.name);
+                        });
                         spaceSystems.forEach(spaceSystem => {
-                            this.addSpaceSystem(spaceSystem)
-                        })
+                            this.addSpaceSystem(spaceSystem);
+                        });
                         if (parameters.parameters !== undefined) {
                             parameters.parameters.forEach(parameter => {
-                                this.addParameterObject(parameter)
-                            })
+                                this.addParameterObject(parameter);
+                            });
                         }
                         this.dictionaryPromise = undefined;
-                        let objects = this.objects;
+
                         return this.objects;
                     });
             });
@@ -103,7 +103,7 @@ export default class YamcsObjectProvider {
     }
 
     getMdbUrl(operation, name='') {
-        return this.url + 'api/mdb/' + this.instance + '/' + operation + name
+        return this.url + 'api/mdb/' + this.instance + '/' + operation + name;
     }
 
     fetchMdbApi(operation, name='') {
@@ -118,19 +118,19 @@ export default class YamcsObjectProvider {
             if (spaceSystem.sub !== undefined) {
                 /* Sort the subsidiary space systems by name. */
                 spaceSystem.sub.sort((a, b) => {
-                    return a.name.localeCompare(b.name)
-                })
+                    return a.name.localeCompare(b.name);
+                });
                 spaceSystem.sub.forEach(sub => {
-                    let subId = qualifiedNameToId(sub.qualifiedName)
+                    let subId = qualifiedNameToId(sub.qualifiedName);
                     composition.push({
                         key: subId,
                         namespace: this.namespace
-                    })
-                })
+                    });
+                });
             }
 
             let id = qualifiedNameToId(spaceSystem.qualifiedName);
-            const locationId = id.substring(0, id.lastIndexOf('~')); 
+            const locationId = id.substring(0, id.lastIndexOf('~'));
             const isSubSystem = locationId.includes('~');
             const key = isSubSystem ? locationId : this.key;
             const location = this.openmct.objects.makeKeyString({
@@ -148,14 +148,14 @@ export default class YamcsObjectProvider {
                 location: location
             };
 
-            this.addObject(obj)
+            this.addObject(obj);
 
             /* Add the space system to the root object if it's top-level. */
             if (spaceSystem.qualifiedName.lastIndexOf('/') === 0) {
                 this.rootObject.composition.push({
                     key: id,
                     namespace: this.namespace
-                })
+                });
             }
         }
     }
@@ -170,19 +170,19 @@ export default class YamcsObjectProvider {
      */
     addParameterObject(parameter) {
         if (!this.isSuppressed(parameter)) {
-            let qn = parameter.qualifiedName
-            let lastSlashPos = qn.lastIndexOf('/')
-            let parentId = qualifiedNameToId(qn.substring(0, lastSlashPos))
-            let parent = this.objects[parentId]
+            let qn = parameter.qualifiedName;
+            let lastSlashPos = qn.lastIndexOf('/');
+            let parentId = qualifiedNameToId(qn.substring(0, lastSlashPos));
+            let parent = this.objects[parentId];
 
-            this.addParameter(parameter, qn, parent, '')
+            this.addParameter(parameter, qn, parent, '');
         }
     }
 
     isSuppressed(parameter) {
         return (parameter.alias && parameter.alias.some(alias => {
-            return (alias.namespace === 'OpenMCT:omit')
-        }))
+            return (alias.namespace === 'OpenMCT:omit');
+        }));
     }
 
     addParameter(parameter, qualifiedName, parent, prefix) {
@@ -208,7 +208,7 @@ export default class YamcsObjectProvider {
         }
 
         if (isAggregate) {
-            obj.type = ;
+            obj.type = 'noneditable.folder';
             obj.composition = [];
         } else {
             obj.type = this.getParameterType(parameter);
@@ -250,8 +250,7 @@ export default class YamcsObjectProvider {
                 parameter.type.member.forEach(member => {
                     let memberQualifiedName = qualifiedName + '.' + member.name;
                     /* Use current name as a prefix for the member name. */
-                    this.addParameter(member, memberQualifiedName, obj,
-                                      name + '_');
+                    this.addParameter(member, memberQualifiedName, obj, name + '_');
                 });
             }
         }

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -53,7 +53,7 @@ export default class YamcsObjectProvider {
                 namespace: this.namespace
             },
             name: this.folderName,
-            type: 'folder',
+            type: 'noneditable.folder',
             location: 'ROOT',
             composition: []
         };
@@ -143,7 +143,7 @@ export default class YamcsObjectProvider {
                     namespace: this.namespace
                 },
                 name: spaceSystem.name,
-                type: 'folder',
+                type: 'noneditable.folder',
                 composition: composition,
                 location: location
             };
@@ -208,7 +208,7 @@ export default class YamcsObjectProvider {
         }
 
         if (isAggregate) {
-            obj.type = 'folder';
+            obj.type = ;
             obj.composition = [];
         } else {
             obj.type = this.getParameterType(parameter);


### PR DESCRIPTION
Added openmct as a parameter to the historical telemetry provider so we can use telemetry api to check for imagery hints (technically could just replicate if there are any issues with that). If it is imagery, pass in imagery flag and do not use samples endpoint. This is combined with @nikhilmandlik updates for minmax since they're modifying same code.

closes #27 

### Author Checklist
Check | Passed
-- | --
Changes address original issue? | Y
Unit tests included and/or updated with changes? | N/A
Command line build passes? | Yes
Changes have been smoke-tested? | Partially Need to test with images on server
Testing instructions included? | Yes