### PR TITLE
Implements new websockets interface for Events stream only

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -21,7 +21,8 @@
  *****************************************************************************/
 
 import YamcsHistoricalTelemetryProvider from './providers/historical-telemetry-provider.js';
-import YamcsRealtimeTelemetryProvider from './providers/realtime-telemetry-provider.js';
+import RealtimeTelemetryProvider from './providers/realtime-telemetry-provider.js';
+import RealtimeEventsProvider from './providers/realtime-events-provider.js';
 import YamcsObjectProvider from './providers/object-provider.js';
 import LimitProvider from './providers/limit-provider';
 
@@ -47,12 +48,19 @@ export default function installYamcsPlugin(configuration) {
             configuration.yamcsInstance);
         openmct.telemetry.addProvider(historicalProvider);
 
-        const realtimeProvider = new YamcsRealtimeTelemetryProvider(
+        const realtimeTelemetryProvider = new RealtimeTelemetryProvider(
             configuration.yamcsRealtimeEndpoint,
             configuration.yamcsInstance
         );
-        openmct.telemetry.addProvider(realtimeProvider);
-        realtimeProvider.connect();
+        openmct.telemetry.addProvider(realtimeTelemetryProvider);
+        realtimeTelemetryProvider.connect();
+
+        const realtimeEventsProvider = new RealtimeEventsProvider(
+            configuration.yamcsRealtimeEndpoint,
+            configuration.yamcsInstance
+        );
+        openmct.telemetry.addProvider(realtimeEventsProvider);
+        realtimeEventsProvider.connect();
 
         openmct.telemetry.addProvider(new LimitProvider());
 

--- a/src/providers/messages.js
+++ b/src/providers/messages.js
@@ -1,0 +1,25 @@
+export const SUBSCRIBE = {
+    'yamcs.events': (subscriptionDetails) => {
+        return `{
+            "type": "events",
+            "id": "${subscriptionDetails.subscriptionId}",
+            "options": {
+                "instance": "${subscriptionDetails.instance}"
+            }
+          }`;
+    }
+};
+
+export const UNSUBSCRIBE = {
+    'yamcs.events': (subscriptionDetails) => {
+        return `{
+            "type": "cancel",
+            "options": {
+                "call": "${subscriptionDetails.call}"
+            }
+          }`;
+    }
+};
+
+export const DATA_TYPE_REPLY = 'reply';
+export const DATA_TYPE_EVENTS = 'events';

--- a/src/providers/realtime-events-provider.js
+++ b/src/providers/realtime-events-provider.js
@@ -161,7 +161,7 @@ export default class RealtimeEventsProvider {
             delete this.reconnectTimeout;
         }, FALLBACK_AND_WAIT_MS[this.currentWaitIndex]);
 
-        if (this.currentWaitIndex < FALLBACK_AND_WAIT_MS.length) {
+        if (this.currentWaitIndex < FALLBACK_AND_WAIT_MS.length - 1) {
             this.currentWaitIndex++;
         }
     }

--- a/src/providers/realtime-events-provider.js
+++ b/src/providers/realtime-events-provider.js
@@ -26,7 +26,7 @@ import * as MESSAGES from './messages';
 const FALLBACK_AND_WAIT_MS = [1000, 5000, 5000, 10000, 10000, 30000];
 
 export default class RealtimeEventsProvider {
-    constructor(url ,instance) {
+    constructor(url, instance) {
         this.url = url;
         this.instance = instance;
         this.connected = false;

--- a/src/providers/realtime-telemetry-provider.js
+++ b/src/providers/realtime-telemetry-provider.js
@@ -153,7 +153,7 @@ export default class RealtimeTelemetryProvider {
             delete this.reconnectTimeout;
         }, FALLBACK_AND_WAIT_MS[this.currentWaitIndex]);
 
-        if (this.currentWaitIndex < FALLBACK_AND_WAIT_MS.length) {
+        if (this.currentWaitIndex < FALLBACK_AND_WAIT_MS.length - 1) {
             this.currentWaitIndex++;
         }
     }


### PR DESCRIPTION
Fixes https://github.com/akhenry/openmct-yamcs/issues/41

This PR implements the new WebSockets interface for Events only. It also addresses two previously unknown bugs:

1. Since the previous implementation of the events stream, unsubscribe was not actually working correctly [due to a missing function argument](https://github.com/akhenry/openmct-yamcs/compare/events-websockets?expand=1#diff-677a8e2dd3c23c1c319c7acfdf6e8292cb91a91b82dcd6f4565ab49bd4119f39R74).
2. WebSocket connection error handling was not actually working correctly [due to an array pointer overflow issue](https://github.com/akhenry/openmct-yamcs/compare/events-websockets?expand=1#diff-677a8e2dd3c23c1c319c7acfdf6e8292cb91a91b82dcd6f4565ab49bd4119f39R156).

### Author Checklist
1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A - Open MCT YAMCS adapter does not have unit tests yet.
3. Command line build passes? Y
4. Changes have been smoke-tested? Y
5. Testing instructions included? Y