### PR TITLE
Fix websocket endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ openmct.install(installYamcsPlugin({
 |-------------------------|-------------------------------------------------------|------------------------------------|
 | yamcsDictionaryEndpoint | This is the root path to the YAMCS installation. The adapter will use this to fetch all of the parameters adapter will use this to fetch all of the parameters and containers defined for the configured instance. | http://localhost:8090/              |
 | yamcsHistoricalEndpoint | As above, this is the root path to the YAMCS installation. This will be automatically appended with the necessary path to retrieve historical data for the selected parameter, in the configured instance. | http://localhost:8090/             |
-| yamcsRealtimeEndpoint   | As above, this is the root path to the YAMCS installation. This will be automatically appended with the necessary path to retrieve historical instance. *It must always start with `ws` or `wss`* | ws://localhost:8090/               |
+| yamcsRealtimeEndpoint   | As above, this is the root path to the YAMCS installation. This will be automatically appended with the necessary path to retrieve realtime data *from the legacy WebSocket interface*. *It must always start with `ws` or `wss`* | ws://localhost:8090/               |
+| yamcsWebsocketEndpoint   | The path to the new (post v5) WebSocket interface.  *It must always start with `ws` or `wss`, and must contain the complete path (unlike config above) | ws://localhost:8090/api/websocket               |
 | yamcsInstance           | The name of the instance configured in YAMCS that you wish to connect to. | myproject                          |
 | yamcsFolder             | The name of the instance configured in YAMCS that you wish to connect to. | myproject                          |
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -56,7 +56,7 @@ export default function installYamcsPlugin(configuration) {
         realtimeTelemetryProvider.connect();
 
         const realtimeEventsProvider = new RealtimeEventsProvider(
-            configuration.yamcsRealtimeEndpoint,
+            configuration.yamcsWebsocketEndpoint,
             configuration.yamcsInstance
         );
         openmct.telemetry.addProvider(realtimeEventsProvider);

--- a/src/providers/realtime-events-provider.js
+++ b/src/providers/realtime-events-provider.js
@@ -94,7 +94,7 @@ export default class RealtimeEventsProvider {
         if (this.connected) {
             return;
         }
-        let wsUrl = `${this.url}api/websocket`;
+        let wsUrl = `${this.url}`;
         this.lastSubscriptionId = 1;
         this.connected = false;
         this.socket = new WebSocket(wsUrl);


### PR DESCRIPTION
Fixes an issue in the implementation of  #41
This how the WebSocket URL is handled in the Open MCT-YAMCS adapter. This change makes it easier to configure the WebSocket endpoint when it is behind a reverse proxy.

### Testing instructions
This changes how the new WebSocket endpoint is configured. Right now this is only used for streaming real-time Events.

Testers should follow [the instructions for testing Events](https://github.com/akhenry/openmct-yamcs/issues/41)

### Author Checklist
1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A
3. Command line build passes? Y
4. Changes have been smoke-tested? Y
5. Testing instructions included? Y