### PR TITLE
Utilize Token for Parameter Requests over a 1000

### DIFF
--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -201,8 +201,8 @@ export default class YamcsObjectProvider {
                         spaceSystems.forEach(spaceSystem => {
                             this.addSpaceSystem(spaceSystem);
                         });
-                        if (parameters.parameters !== undefined) {
-                            parameters.parameters.forEach(parameter => {
+                        if (parameters !== undefined) {
+                            parameters.forEach(parameter => {
                                 this.addParameterObject(parameter);
                             });
                         }

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -190,7 +190,7 @@ export default class YamcsObjectProvider {
         if(this.dictionaryPromise === undefined) {
             let url = this.getMdbUrl('space-systems');
             this.dictionaryPromise = accumulateResults(url, 'spaceSystems', []).then(spaceSystems => {
-                return this.accumulateResults(parameterUrl, 'parameters', [])
+                return accumulateResults(parameterUrl, 'parameters', [])
                     .then(parameters => {
                         /* Sort the space systems by name, so that the
                            children of the root object are in sorted order. */

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -184,10 +184,13 @@ export default class YamcsObjectProvider {
     }
 
     fetchTelemetryDictionary() {
+        const operation = 'parameters?details=yes&limit=1000';
+        const parameterUrl = this.url + 'api/mdb/' + this.instance + '/' + operation;
+
         if(this.dictionaryPromise === undefined) {
             let url = this.getMdbUrl('space-systems');
             this.dictionaryPromise = accumulateResults(url, 'spaceSystems', []).then(spaceSystems => {
-                return this.fetchMdbApi('parameters?details=yes&limit=1000')
+                return this.accumulateResults(parameterUrl, 'parameters', [])
                     .then(parameters => {
                         /* Sort the space systems by name, so that the
                            children of the root object are in sorted order. */

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -192,6 +192,7 @@ export default class YamcsObjectProvider {
             this.dictionaryPromise = accumulateResults(url, 'spaceSystems', []).then(spaceSystems => {
                 return accumulateResults(parameterUrl, 'parameters', [])
                     .then(parameters => {
+                        console.log('parameters from accumulate', parameters);
                         /* Sort the space systems by name, so that the
                            children of the root object are in sorted order. */
                         spaceSystems.sort((a, b) => {

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -192,7 +192,6 @@ export default class YamcsObjectProvider {
             this.dictionaryPromise = accumulateResults(url, 'spaceSystems', []).then(spaceSystems => {
                 return accumulateResults(parameterUrl, 'parameters', [])
                     .then(parameters => {
-                        console.log('parameters from accumulate', parameters);
                         /* Sort the space systems by name, so that the
                            children of the root object are in sorted order. */
                         spaceSystems.sort((a, b) => {

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -201,11 +201,11 @@ export default class YamcsObjectProvider {
                         spaceSystems.forEach(spaceSystem => {
                             this.addSpaceSystem(spaceSystem);
                         });
-                        if (parameters !== undefined) {
-                            parameters.forEach(parameter => {
-                                this.addParameterObject(parameter);
-                            });
-                        }
+
+                        parameters.forEach(parameter => {
+                            this.addParameterObject(parameter);
+                        });
+
                         this.dictionaryPromise = undefined;
 
                         return this.objects;

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,6 +70,7 @@ function getValue(value) {
  *     a promise for an array of results accumulated over the requests
  */
 function accumulateResults(url, property, soFar, totalLimit, token) {
+    console.log('accumulate results', url, property);
     if (totalLimit === undefined) {
         totalLimit = 1000000;
     }
@@ -85,6 +86,7 @@ function accumulateResults(url, property, soFar, totalLimit, token) {
 
     const result = fetch(newUrl).then(res => {return res.json();});
     return result.then(res => {
+        console.log('res', res);
         if (property in res) {
             soFar = soFar.concat(res[property]);
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,7 +70,6 @@ function getValue(value) {
  *     a promise for an array of results accumulated over the requests
  */
 function accumulateResults(url, property, soFar, totalLimit, token) {
-    console.log('accumulate results', url, property);
     if (totalLimit === undefined) {
         totalLimit = 1000000;
     }
@@ -86,7 +85,6 @@ function accumulateResults(url, property, soFar, totalLimit, token) {
 
     const result = fetch(newUrl).then(res => {return res.json();});
     return result.then(res => {
-        console.log('res', res);
         if (property in res) {
             soFar = soFar.concat(res[property]);
         }


### PR DESCRIPTION
Utilizing the accumulateResults function which handles tokens when requests produce more than 1000 results. Enabling this for parameters.

closes #47 

### Author Checklist
Check | Passed
-- | --
Changes address original issue? | Y
Unit tests included and/or updated with changes? | N
Command line build passes? | Y
Changes have been smoke-tested? | Y
Testing instructions included? | Y