### PR TITLE
[Historical Telemetry Provider] Auto-page responses

### DIFF
--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -56,6 +56,7 @@ export default class YamcsHistoricalTelemetryProvider {
     }
 
     getHistory(id, options, isImagery) {
+        console.log('get history', options);
         let {
             start,
             end,
@@ -76,15 +77,19 @@ export default class YamcsHistoricalTelemetryProvider {
         let sizeParam = 'limit';
         let convertHistory = (res) => this.convertPointHistory(id, res);
 
-        if (strategy && strategy.toLowerCase() === 'latest') {
-            size = 1;
-            order = 'desc';
-        } else if (strategy && strategy.toLowerCase() === 'minmax' && !isImagery) {
-            responseKeyName = 'sample';
-            url += '/samples';
+        if (strategy) {
+            let lcStrategy = strategy.toLowerCase();
 
-            sizeParam = 'count';
-            convertHistory = (res) => this.convertSampleHistory(id, res);
+            if (lcStrategy === 'latest') {
+                size = 1;
+                order = 'desc';
+            } else if (lcStrategy === 'minmax' && !isImagery) {
+                responseKeyName = 'sample';
+                url += '/samples';
+
+                sizeParam = 'count';
+                convertHistory = (res) => this.convertSampleHistory(id, res);
+            }
         }
 
         url += `?start=${new Date(start).toISOString()}`;
@@ -94,10 +99,6 @@ export default class YamcsHistoricalTelemetryProvider {
 
         return accumulateResults(url, responseKeyName, [])
             .then(convertHistory);
-
-        // return fetch(encodeURI(url))
-        //     .then(res => res.json())
-        //     .then(convertHistory);
     }
 
     getLinkParamsSpecificToId(id) {

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -122,7 +122,7 @@ export default class YamcsHistoricalTelemetryProvider {
         if (!results) {
             return [];
         }
-
+        console.log('convert event history', id, results);
         return results.map(e => {
             return {
                 id,
@@ -135,6 +135,7 @@ export default class YamcsHistoricalTelemetryProvider {
         if (id === OBJECT_TYPES.EVENTS_OBJECT_TYPE) {
             return this.convertEventHistory(id, results);
         }
+        console.log('convert point history', id, results);
 
         if (!(results)) {
             return [];
@@ -159,7 +160,7 @@ export default class YamcsHistoricalTelemetryProvider {
         if (!(results)) {
             return [];
         }
-
+        console.log('convert sample history', id, results);
         let values = [];
         results.forEach(result => {
             if (result.n > 0) {

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -56,7 +56,7 @@ export default class YamcsHistoricalTelemetryProvider {
     }
 
     getHistory(id, options, isImagery) {
-        console.log('get history', options);
+
         let {
             start,
             end,
@@ -123,7 +123,7 @@ export default class YamcsHistoricalTelemetryProvider {
         if (!results) {
             return [];
         }
-        console.log('convert event history', id, results);
+
         return results.map(e => {
             return {
                 id,
@@ -136,7 +136,7 @@ export default class YamcsHistoricalTelemetryProvider {
         if (id === OBJECT_TYPES.EVENTS_OBJECT_TYPE) {
             return this.convertEventHistory(id, results);
         }
-        console.log('convert point history', id, results);
+
 
         if (!(results)) {
             return [];
@@ -161,7 +161,7 @@ export default class YamcsHistoricalTelemetryProvider {
         if (!(results)) {
             return [];
         }
-        console.log('convert sample history', id, results);
+
         let values = [];
         results.forEach(result => {
             if (result.n > 0) {

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -58,7 +58,7 @@ export default class YamcsHistoricalTelemetryProvider {
         let {
             start,
             end,
-            size = 300,
+            size = 1000,
             strategy
         } = options;
 

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -80,6 +80,7 @@ export default class YamcsHistoricalTelemetryProvider {
             size = 1;
             order = 'desc';
         } else if (strategy && strategy.toLowerCase() === 'minmax' && !isImagery) {
+            responseKeyName = 'sample';
             url += '/samples';
 
             sizeParam = 'count';
@@ -118,11 +119,11 @@ export default class YamcsHistoricalTelemetryProvider {
     }
 
     convertEventHistory(id, results) {
-        if (!results.event) {
+        if (!results) {
             return [];
         }
 
-        return results.event.map(e => {
+        return results.map(e => {
             return {
                 id,
                 ...e
@@ -135,19 +136,19 @@ export default class YamcsHistoricalTelemetryProvider {
             return this.convertEventHistory(id, results);
         }
 
-        if (!(results.parameter)) {
+        if (!(results)) {
             return [];
         }
 
         let values = [];
-        results.parameter.forEach(parameter => {
+        results.forEach(result => {
             let point = {
-                id: parameter.id.name,
-                timestamp: parameter.generationTimeUTC,
-                value: getValue(parameter.engValue)
+                id: result.id.name,
+                timestamp: result.generationTimeUTC,
+                value: getValue(result.engValue)
             };
 
-            addLimitInformation(parameter, point);
+            addLimitInformation(result, point);
             values.push(point);
         });
 
@@ -155,31 +156,31 @@ export default class YamcsHistoricalTelemetryProvider {
     }
 
     convertSampleHistory(id, results) {
-        if (!(results.sample)) {
+        if (!(results)) {
             return [];
         }
 
         let values = [];
-        results.sample.forEach(sample => {
-            if (sample.n > 0) {
+        results.forEach(result => {
+            if (result.n > 0) {
                 let min_value = {
-                    timestamp: sample.time,
-                    value: sample.min,
+                    timestamp: result.time,
+                    value: result.min,
                     id: id
                 };
 
-                addLimitInformation(sample, min_value);
+                addLimitInformation(result, min_value);
                 values.push(min_value);
             }
 
-            if (sample.n > 1) {
+            if (result.n > 1) {
                 let max_value = {
-                    timestamp: sample.time,
-                    value: sample.max,
+                    timestamp: result.time,
+                    value: result.max,
                     id: id
                 };
 
-                addLimitInformation(sample, max_value);
+                addLimitInformation(result, max_value);
                 values.push(max_value);
             }
         });

--- a/src/utils.js
+++ b/src/utils.js
@@ -114,6 +114,8 @@ function accumulateResults(url, property, soFar, totalLimit, token) {
         totalLimit = 1000000;
     }
 
+    console.log('accumulate results', url, property, token);
+
     let newUrl = url;
     if (token !== undefined) {
         if (url.indexOf('?') < 0) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -114,8 +114,6 @@ function accumulateResults(url, property, soFar, totalLimit, token) {
         totalLimit = 1000000;
     }
 
-    console.log('accumulate results', url, property, token);
-
     let newUrl = url;
     if (token !== undefined) {
         if (url.indexOf('?') < 0) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -123,7 +123,7 @@ function accumulateResults(url, property, soFar, totalLimit, token) {
         }
     }
 
-    const result = fetch(newUrl)
+    const result = fetch(encodeURI(newUrl))
         .then(res => res.json());
 
     return result.then(res => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -123,7 +123,9 @@ function accumulateResults(url, property, soFar, totalLimit, token) {
         }
     }
 
-    const result = fetch(newUrl).then(res => {return res.json();});
+    const result = fetch(newUrl)
+        .then(res => res.json());
+
     return result.then(res => {
         if (property in res) {
             soFar = soFar.concat(res[property]);


### PR DESCRIPTION
If the presence of a continuationToken exists on the response for historical requests, then auto request until no more continuationTokens exist and concatenate the results. This will bypass the 1000 result limit inherent in YAMCS.

closes #62 

### Author Checklist
Check | Passed
-- | --
Changes address original issue? | Y
Unit tests included and/or updated with changes? | N
Command line build passes? | Y
Changes have been smoke-tested? | Y
Testing instructions included? | Y