### PR TITLE
[Historical Telemetry Provider] Abort requests on destroy

### DIFF
--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -61,7 +61,8 @@ export default class YamcsHistoricalTelemetryProvider {
             start,
             end,
             size,
-            strategy
+            strategy,
+            signal
         } = options;
         let totalRequestSize = size;
 
@@ -100,7 +101,7 @@ export default class YamcsHistoricalTelemetryProvider {
         url += `&${sizeParam}=${size}`;
         url += `&order=${order}`;
 
-        return accumulateResults(url, responseKeyName, [], totalRequestSize)
+        return accumulateResults(url, { signal }, responseKeyName, [], totalRequestSize)
             .then(convertHistory);
     }
 

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -102,7 +102,10 @@ export default class YamcsHistoricalTelemetryProvider {
         url += `&order=${order}`;
 
         return accumulateResults(url, { signal }, responseKeyName, [], totalRequestSize)
-            .then(convertHistory);
+            .then(convertHistory)
+            .catch((error) => {
+                console.log('error', error);
+            });
     }
 
     getLinkParamsSpecificToId(id) {

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -102,10 +102,7 @@ export default class YamcsHistoricalTelemetryProvider {
         url += `&order=${order}`;
 
         return accumulateResults(url, { signal }, responseKeyName, [], totalRequestSize)
-            .then(convertHistory)
-            .catch((error) => {
-                console.log('error', error);
-            });
+            .then(convertHistory);
     }
 
     getLinkParamsSpecificToId(id) {

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -189,8 +189,8 @@ export default class YamcsObjectProvider {
 
         if(this.dictionaryPromise === undefined) {
             let url = this.getMdbUrl('space-systems');
-            this.dictionaryPromise = accumulateResults(url, 'spaceSystems', []).then(spaceSystems => {
-                return accumulateResults(parameterUrl, 'parameters', [])
+            this.dictionaryPromise = accumulateResults(url, {}, 'spaceSystems', []).then(spaceSystems => {
+                return accumulateResults(parameterUrl, {}, 'parameters', [])
                     .then(parameters => {
                         /* Sort the space systems by name, so that the
                            children of the root object are in sorted order. */

--- a/src/utils.js
+++ b/src/utils.js
@@ -111,7 +111,7 @@ function warnUnsupportedType(type) {
  */
 function accumulateResults(url, options, property, soFar, totalLimit, token) {
     if (options.signal && options.signal.aborted) {
-        return;
+        return [];
     }
 
     if (totalLimit === undefined) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -110,6 +110,10 @@ function warnUnsupportedType(type) {
  *     a promise for an array of results accumulated over the requests
  */
 function accumulateResults(url, options, property, soFar, totalLimit, token) {
+    if (options.signal && options.signal.aborted) {
+        return;
+    }
+
     if (totalLimit === undefined) {
         totalLimit = 1000000;
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -109,7 +109,7 @@ function warnUnsupportedType(type) {
  * Returns:
  *     a promise for an array of results accumulated over the requests
  */
-function accumulateResults(url, property, soFar, totalLimit, token) {
+function accumulateResults(url, options, property, soFar, totalLimit, token) {
     if (totalLimit === undefined) {
         totalLimit = 1000000;
     }
@@ -123,7 +123,7 @@ function accumulateResults(url, property, soFar, totalLimit, token) {
         }
     }
 
-    const result = fetch(encodeURI(newUrl))
+    const result = fetch(encodeURI(newUrl), options)
         .then(res => res.json());
 
     return result.then(res => {
@@ -133,7 +133,7 @@ function accumulateResults(url, property, soFar, totalLimit, token) {
         if (res.continuationToken===undefined || soFar.length >= totalLimit) {
             return soFar;
         }
-        return accumulateResults(url, property, soFar, totalLimit,
+        return accumulateResults(url, options, property, soFar, totalLimit,
             res.continuationToken);
     });
 }


### PR DESCRIPTION
Added the ability to accept options (and subsequently an abort signal) when requesting telemetry or objects. Updated the accumulateResults utility function to use abort signals.

closes #70 

### Author Checklist
Check | Passed
-- | --
Changes address original issue? | Y
Unit tests included and/or updated with changes? | N/A
Command line build passes? | Y
Changes have been smoke-tested? | Y
Testing instructions included? | Y