### PR TITLE
[Events] Wrong key for time and source

### DIFF
--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -86,6 +86,7 @@ export default class YamcsObjectProvider {
                     },
                     {
                         key: 'utc',
+                        source: 'generationTime',
                         name: 'Generation Time',
                         hints: {
                             domain: 1

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -85,7 +85,7 @@ export default class YamcsObjectProvider {
                         name: 'Severity'
                     },
                     {
-                        key: 'generationTime',
+                        key: 'utc',
                         name: 'Generation Time',
                         hints: {
                             domain: 1


### PR DESCRIPTION
Need to update time key for event metadata to 'utc' and source to 'generationTime'.

closes #78 