### PR TITLE
[Yield Historical Telemtry] To improve view performance in Open MCT

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -70,7 +70,7 @@ export default function installYamcsPlugin(configuration) {
 
         openmct.types.addType(OBJECT_TYPES.AGGREGATE_TELEMETRY_TYPE, {
             name: 'Aggregate Telemetry Points',
-            description: 'Aggregate Spacecraft Telemetry points',
+            description: 'Aggregate Spacecraft Telemetry Points',
             cssClass: 'icon-telemetry-aggregate'
         });
 

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -67,20 +67,6 @@ export default class YamcsHistoricalTelemetryProvider {
     }
 
     getHistory(id, url, options) {
-        let responseKeyName = this.getResponseKeyById(id);
-
-        return accumulateResults(url, { signal: options.signal }, responseKeyName, [], options.totalRequestSize)
-            .then((res) => this.convertPointHistory(id, res));
-    }
-
-    getMinMaxHistory(id, url, options) {
-        let responseKeyName = 'sample';
-
-        return accumulateResults(url, { signal: options.signal }, responseKeyName, [], options.totalRequestSize)
-            .then((res) => this.convertSampleHistory(id, res));
-    }
-
-    yieldHistory(id, url, options) {
         options.responseKeyName = this.getResponseKeyById(id);
 
         if (!options.yieldRequestProcessor) {
@@ -92,6 +78,17 @@ export default class YamcsHistoricalTelemetryProvider {
 
             return Promise.resolve([]);
         }
+        // let responseKeyName = this.getResponseKeyById(id);
+
+        // return accumulateResults(url, { signal: options.signal }, responseKeyName, [], options.totalRequestSize)
+        //     .then((res) => this.convertPointHistory(id, res));
+    }
+
+    getMinMaxHistory(id, url, options) {
+        let responseKeyName = 'sample';
+
+        return accumulateResults(url, { signal: options.signal }, responseKeyName, [], options.totalRequestSize)
+            .then((res) => this.convertSampleHistory(id, res));
     }
 
     yieldMinMaxHistory(id, url, options) {

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -73,7 +73,7 @@ export default class YamcsHistoricalTelemetryProvider {
             return accumulateResults(url, { signal: options.signal }, options.responseKeyName, [], options.totalRequestSize)
                 .then((res) => this.convertPointHistory(id, res));
         } else {
-            options.formatter = (res) => { console.log('formatter', res, this.convertPointHistory); this.convertPointHistory(id, res); };
+            options.formatter = (res) => this.convertPointHistory(id, res);
 
             return yieldResults(url, options);
         }

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -91,13 +91,6 @@ export default class YamcsHistoricalTelemetryProvider {
             .then((res) => this.convertSampleHistory(id, res));
     }
 
-    yieldMinMaxHistory(id, url, options) {
-        let responseKeyName = 'sample';
-
-        return accumulateResults(url, { signal: options.signal }, responseKeyName, [], options.totalRequestSize)
-            .then((res) => this.convertSampleHistory(id, res));
-    }
-
     standardizeOptions(options, domainObject) {
         options.sizeType = 'count';
         options.order = 'asc';

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -77,17 +77,19 @@ export default class YamcsHistoricalTelemetryProvider {
 
             return yieldResults(url, options);
         }
-        // let responseKeyName = this.getResponseKeyById(id);
-
-        // return accumulateResults(url, { signal: options.signal }, responseKeyName, [], options.totalRequestSize)
-        //     .then((res) => this.convertPointHistory(id, res));
     }
 
     getMinMaxHistory(id, url, options) {
-        let responseKeyName = 'sample';
+        options.responseKeyName = 'sample';
 
-        return accumulateResults(url, { signal: options.signal }, responseKeyName, [], options.totalRequestSize)
-            .then((res) => this.convertSampleHistory(id, res));
+        if (!options.yieldRequestProcessor) {
+            return accumulateResults(url, { signal: options.signal }, options.responseKeyName, [], options.totalRequestSize)
+                .then((res) => this.convertSampleHistory(id, res));
+        } else {
+            options.formatter = (res) => this.convertSampleHistory(id, res);
+
+            return yieldResults(url, options);
+        }
     }
 
     standardizeOptions(options, domainObject) {

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -69,13 +69,8 @@ export default class YamcsHistoricalTelemetryProvider {
     getHistory(id, url, options) {
         let responseKeyName = this.getResponseKeyById(id);
 
-        if (!options.yieldRequestCallback) {
-            return accumulateResults(url, { signal: options.signal }, responseKeyName, [], options.totalRequestSize)
-                .then((res) => this.convertPointHistory(id, res));
-        } else {
-            return yieldResults(url, { signal: options.signal }, responseKeyName, [], options.totalRequestSize)
-                .then((res) => this.convertPointHistory(id, res));
-        }
+        return accumulateResults(url, { signal: options.signal }, responseKeyName, [], options.totalRequestSize)
+            .then((res) => this.convertPointHistory(id, res));
     }
 
     getMinMaxHistory(id, url, options) {
@@ -86,10 +81,17 @@ export default class YamcsHistoricalTelemetryProvider {
     }
 
     yieldHistory(id, url, options) {
-        let responseKeyName = this.getResponseKeyById(id);
+        options.responseKeyName = this.getResponseKeyById(id);
 
-        return accumulateResults(url, { signal: options.signal }, responseKeyName, [], options.totalRequestSize)
-            .then((res) => this.convertPointHistory(id, res));
+        if (!options.yieldRequestProcessor) {
+            return accumulateResults(url, { signal: options.signal }, options.responseKeyName, [], options.totalRequestSize)
+                .then((res) => this.convertPointHistory(id, res));
+        } else {
+            options.formatter = (res) => this.convertPointHistory(id, res).bind(this);
+            yieldResults(url, options);
+
+            return Promise.resolve([]);
+        }
     }
 
     yieldMinMaxHistory(id, url, options) {

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -73,7 +73,7 @@ export default class YamcsHistoricalTelemetryProvider {
             return accumulateResults(url, { signal: options.signal }, options.responseKeyName, [], options.totalRequestSize)
                 .then((res) => this.convertPointHistory(id, res));
         } else {
-            options.formatter = (res) => this.convertPointHistory(id, res).bind(this);
+            options.formatter = (res) => { console.log('formatter', res, this); this.convertPointHistory(id, res); };
             yieldResults(url, options);
 
             return Promise.resolve([]);

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -106,9 +106,7 @@ export default class YamcsHistoricalTelemetryProvider {
                 options.size = 1;
                 options.totalRequestSize = 1;
                 options.order = 'desc';
-            }
-
-            if (
+            } else if (
                 options.strategy === 'minmax'
                 && domainObject.type !== OBJECT_TYPES.AGGREGATE_TELEMETRY_TYPE
             ) {

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -48,7 +48,7 @@ export default class YamcsHistoricalTelemetryProvider {
         return this.supportedTypes[domainObject.type];
     }
 
-    request(domainObject, options) {
+    request(domainObject, options, yieldResults = false) {
         this.standardizeOptions(options, domainObject);
 
         let id = domainObject.identifier.key;
@@ -74,6 +74,20 @@ export default class YamcsHistoricalTelemetryProvider {
     }
 
     getMinMaxHistory(id, url, options) {
+        let responseKeyName = 'sample';
+
+        return accumulateResults(url, { signal: options.signal }, responseKeyName, [], options.totalRequestSize)
+            .then((res) => this.convertSampleHistory(id, res));
+    }
+
+    yieldHistory(id, url, options) {
+        let responseKeyName = this.getResponseKeyById(id);
+
+        return accumulateResults(url, { signal: options.signal }, responseKeyName, [], options.totalRequestSize)
+            .then((res) => this.convertPointHistory(id, res));
+    }
+
+    yieldMinMaxHistory(id, url, options) {
         let responseKeyName = 'sample';
 
         return accumulateResults(url, { signal: options.signal }, responseKeyName, [], options.totalRequestSize)

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -69,7 +69,7 @@ export default class YamcsHistoricalTelemetryProvider {
     getHistory(id, url, options) {
         options.responseKeyName = this.getResponseKeyById(id);
 
-        if (!options.yieldRequestProcessor) {
+        if (!options.onPartialResponse) {
             return accumulateResults(url, { signal: options.signal }, options.responseKeyName, [], options.totalRequestSize)
                 .then((res) => this.convertPointHistory(id, res));
         } else {
@@ -82,7 +82,7 @@ export default class YamcsHistoricalTelemetryProvider {
     getMinMaxHistory(id, url, options) {
         options.responseKeyName = 'sample';
 
-        if (!options.yieldRequestProcessor) {
+        if (!options.onPartialResponse) {
             return accumulateResults(url, { signal: options.signal }, options.responseKeyName, [], options.totalRequestSize)
                 .then((res) => this.convertSampleHistory(id, res));
         } else {

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -74,9 +74,8 @@ export default class YamcsHistoricalTelemetryProvider {
                 .then((res) => this.convertPointHistory(id, res));
         } else {
             options.formatter = (res) => { console.log('formatter', res, this.convertPointHistory); this.convertPointHistory(id, res); };
-            yieldResults(url, options);
 
-            return Promise.resolve([]);
+            return yieldResults(url, options);
         }
         // let responseKeyName = this.getResponseKeyById(id);
 

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -92,7 +92,7 @@ export default class YamcsHistoricalTelemetryProvider {
     }
 
     standardizeOptions(options, domainObject) {
-        options.sizeType = 'count';
+        options.sizeType = 'limit';
         options.order = 'asc';
         options.isSamples = false;
         options.totalRequestSize = options.size || 1000000;
@@ -112,7 +112,7 @@ export default class YamcsHistoricalTelemetryProvider {
                 options.strategy === 'minmax'
                 && domainObject.type !== OBJECT_TYPES.AGGREGATE_TELEMETRY_TYPE
             ) {
-                options.sizeType = 'limit';
+                options.sizeType = 'count';
                 options.isSamples = true;
             }
         }

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -73,7 +73,7 @@ export default class YamcsHistoricalTelemetryProvider {
             return accumulateResults(url, { signal: options.signal }, options.responseKeyName, [], options.totalRequestSize)
                 .then((res) => this.convertPointHistory(id, res));
         } else {
-            options.formatter = (res) => { console.log('formatter', res, this); this.convertPointHistory(id, res); };
+            options.formatter = (res) => { console.log('formatter', res, this.convertPointHistory); this.convertPointHistory(id, res); };
             yieldResults(url, options);
 
             return Promise.resolve([]);

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -85,7 +85,8 @@ export default class YamcsObjectProvider {
                         name: 'Severity'
                     },
                     {
-                        key: 'generationTime',
+                        key: 'utc',
+                        source: 'generationTime',
                         name: 'Generation Time',
                         hints: {
                             domain: 1

--- a/src/utils.js
+++ b/src/utils.js
@@ -214,7 +214,7 @@ function getHistoryYieldRequest(signal) {
             let url = yield;
             console.log('url', url);
             let result = await fetch(encodeURI(url, { signal})).then(res => res.json());
-
+            console.log('result', result);
             if (!result.continuationToken) {
                 proceed = false;
             }

--- a/src/utils.js
+++ b/src/utils.js
@@ -212,13 +212,14 @@ function getHistoryYieldRequest(signal) {
 
         while (proceed) {
             let url = yield;
-            let results = await fetch(encodeURI(url, { signal})).then(res => res.json());
+            console.log('url', url);
+            let result = await fetch(encodeURI(url, { signal})).then(res => res.json());
 
-            if (!results.continuationToken) {
+            if (!result.continuationToken) {
                 proceed = false;
             }
 
-            yield results;
+            yield result;
         }
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -180,10 +180,11 @@ async function yieldResults(url, options) {
     let data;
 
     while (!stop) {
+        console.log({newUrl});
         result = await fetch(encodeURI(newUrl), { signal });
         result = result.json();
         data = result[responseKeyName];
-
+        console.log({data});
         if (data) {
             count += data.length;
             token = data.continuationToken;
@@ -191,6 +192,7 @@ async function yieldResults(url, options) {
             yieldRequestProcessor.next(formatter(data));
 
             if ((signal && signal.aborted) || !token || count >= totalRequestSize) {
+                console.log('stopping', signal, signal.aborted, token, count, totalRequestSize);
                 stop = true;
             } else {
                 if (url.indexOf('?') < 0) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -183,7 +183,7 @@ async function yieldResults(url, options) {
         console.log({newUrl});
         result = await fetch(encodeURI(newUrl), { signal });
         console.log('result', result, responseKeyName);
-        result = result.json();
+        result = await result.json();
         console.log('result', result);
         data = result[responseKeyName];
         console.log({data});

--- a/src/utils.js
+++ b/src/utils.js
@@ -176,13 +176,13 @@ async function yieldResults(url, { signal, responseKeyName, totalRequestSize, on
             token = result.continuationToken;
             formattedData = formatter(data);
 
+            onPartialResponse(formattedData);
+
             if (token) {
-                onPartialResponse(formattedData);
                 newUrl = addTokenToUrl(url, token);
                 yieldRequestHistory.next();
             } else {
-                onPartialResponse(formattedData);
-                yieldRequestHistory.return(false);
+                yieldRequestHistory.return();
 
                 return [];
             }
@@ -195,7 +195,7 @@ async function yieldResults(url, { signal, responseKeyName, totalRequestSize, on
         }
     }
 
-    yieldRequestHistory.return(false);
+    yieldRequestHistory.return();
 
     return [];
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -152,7 +152,7 @@ function accumulateResults(url, options, property, soFar, totalLimit, token) {
     });
 }
 
-async function yieldResults(url, { signal, responseKeyName, totalRequestSize, onPartialReponse, formatter }) {
+async function yieldResults(url, { signal, responseKeyName, totalRequestSize, onPartialResponse, formatter }) {
 
     if (aborted(signal)) {
         return [];
@@ -177,7 +177,7 @@ async function yieldResults(url, { signal, responseKeyName, totalRequestSize, on
             formattedData = formatter(data);
 
             if (token) {
-                onPartialReponse(formattedData);
+                onPartialResponse(formattedData);
                 newUrl = addTokenToUrl(url, token);
                 yieldRequestHistory.next();
             } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -136,7 +136,6 @@ function accumulateResults(url, options, property, soFar, totalLimit, token) {
     }
 
     let newUrl = addTokenToUrl(url, token);
-    }
 
     const result = fetch(encodeURI(newUrl), options)
         .then(res => res.json());

--- a/src/utils.js
+++ b/src/utils.js
@@ -185,11 +185,11 @@ function yieldResults(url, options) {
             token = result.continuationToken;
             formattedData = formatter(data);
 
-            if (!token) {
-                return formattedData;
-            } else {
+            if (token) {
                 yieldRequestProcessor(formattedData);
                 newUrl = addTokenToUrl(url, token);
+            } else {
+                return formattedData;
             }
 
             if (aborted(signal) || count >= totalRequestSize) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -188,7 +188,7 @@ async function yieldResults(url, options) {
             if (token) {
                 yieldRequestProcessor(formattedData);
                 newUrl = addTokenToUrl(url, token);
-                console.log('new url', newUrl);
+                yieldRequestHistory.next();
             } else {
                 return formattedData;
             }

--- a/src/utils.js
+++ b/src/utils.js
@@ -175,14 +175,12 @@ async function yieldResults(url, options) {
     let formattedData;
 
     while (!stop) {
-        console.log('url sent into yield req hist', newUrl);
         result = await yieldRequestHistory.next(newUrl).value;
         data = result[responseKeyName];
 
         if (data) {
             count += data.length;
             token = result.continuationToken;
-            console.log('token', token);
             formattedData = formatter(data);
 
             if (token) {
@@ -194,7 +192,6 @@ async function yieldResults(url, options) {
             }
 
             if (aborted(signal) || count >= totalRequestSize) {
-                console.log('stopping', aborted(signal), token, count, totalRequestSize);
                 stop = true;
             }
         } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -165,7 +165,7 @@ async function yieldResults(url, options) {
         return [];
     }
 
-    const yieldRequestHistory = getHistoryYieldRequest();
+    const yieldRequestHistory = getHistoryYieldRequest(url, signal);
     let count = 0;
     let stop = false;
     let newUrl = url;
@@ -208,10 +208,10 @@ async function yieldResults(url, options) {
 
 }
 
-function getHistoryYieldRequest(signal) {
+function getHistoryYieldRequest(originalUrl, signal) {
 
     function* yieldRequestHistory() {
-        let url = yield;
+        let url = originalUrl;
 
         do {
             yield fetch(encodeURI(url, { signal}))

--- a/src/utils.js
+++ b/src/utils.js
@@ -135,7 +135,7 @@ function accumulateResults(url, options, property, soFar, totalLimit, token) {
         return [];
     }
 
-    let newUrl = addTokenToUrl(url, token);
+    let newUrl = formatUrl(url, token);
 
     const result = fetch(newUrl, options)
         .then(res => res.json());
@@ -161,7 +161,7 @@ async function yieldResults(url, { signal, responseKeyName, totalRequestSize, on
     const yieldRequestHistory = getHistoryYieldRequest(signal);
     let count = 0;
     let stop = false;
-    let newUrl = addTokenToUrl(url);
+    let newUrl = formatUrl(url);
     let token;
     let result;
     let data;
@@ -179,7 +179,7 @@ async function yieldResults(url, { signal, responseKeyName, totalRequestSize, on
             onPartialResponse(formattedData);
 
             if (token) {
-                newUrl = addTokenToUrl(url, token);
+                newUrl = formatUrl(url, token);
                 yieldRequestHistory.next();
             } else {
                 yieldRequestHistory.return();
@@ -219,7 +219,7 @@ function getHistoryYieldRequest(signal) {
     return generator;
 }
 
-function addTokenToUrl(url, token) {
+function formatUrl(url, token) {
     const urlObject = new URL(url);
 
     if (token !== undefined) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -182,7 +182,9 @@ async function yieldResults(url, options) {
     while (!stop) {
         console.log({newUrl});
         result = await fetch(encodeURI(newUrl), { signal });
+        console.log('result', result, responseKeyName);
         result = result.json();
+        console.log('result', result);
         data = result[responseKeyName];
         console.log({data});
         if (data) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -213,13 +213,16 @@ function getHistoryYieldRequest(signal) {
         while (proceed) {
             let url = yield;
             console.log('url', url);
-            let result = await fetch(encodeURI(url, { signal})).then(res => res.json());
-            console.log('result', result);
-            if (!result.continuationToken) {
-                proceed = false;
-            }
+            yield fetch(encodeURI(url, { signal}))
+                .then(res => res.json())
+                .then(res => {
+                    console.log('res', res);
+                    if (!res.continuationToken) {
+                        proceed = false;
+                    }
 
-            yield result;
+                    return res;
+                });
         }
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -152,7 +152,7 @@ function accumulateResults(url, options, property, soFar, totalLimit, token) {
     });
 }
 
-function yieldResults(url, options) {
+async function yieldResults(url, options) {
     let {
         signal,
         responseKeyName,
@@ -175,7 +175,7 @@ function yieldResults(url, options) {
     let formattedData;
 
     while (!stop) {
-        result = yieldRequestHistory.next(newUrl).value;
+        result = await yieldRequestHistory.next(newUrl).value;
         console.log('result', result);
         data = result[responseKeyName];
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -165,7 +165,6 @@ async function yieldResults(url, { signal, responseKeyName, totalRequestSize, on
     let token;
     let result;
     let data;
-    let formattedData;
 
     while (!stop) {
         result = await yieldRequestHistory.next(newUrl).value;
@@ -174,21 +173,16 @@ async function yieldResults(url, { signal, responseKeyName, totalRequestSize, on
         if (data) {
             count += data.length;
             token = result.continuationToken;
-            formattedData = formatter(data);
 
-            onPartialResponse(formattedData);
+            onPartialResponse(formatter(data));
 
             if (token) {
                 newUrl = formatUrl(url, token);
                 yieldRequestHistory.next();
-            } else {
-                stop = true;
             }
+        }
 
-            if (aborted(signal) || count >= totalRequestSize) {
-                stop = true;
-            }
-        } else {
+        if (aborted(signal) || count >= totalRequestSize || !token || !data) {
             stop = true;
         }
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -207,10 +207,19 @@ async function yieldResults(url, options) {
 
 function getHistoryYieldRequest(signal) {
 
-    function* yieldRequestHistory() {
-        const url = yield;
-        console.log('yielded url', url);
-        yield fetch(encodeURI(url, { signal})).then(res => res.json());
+    async function* yieldRequestHistory() {
+        let proceed = true;
+
+        while (proceed) {
+            let url = yield;
+            let results = await fetch(encodeURI(url, { signal})).then(res => res.json());
+
+            if (!results.continuationToken) {
+                proceed = false;
+            }
+
+            yield results;
+        }
     }
 
     const generator = yieldRequestHistory();

--- a/src/utils.js
+++ b/src/utils.js
@@ -182,9 +182,7 @@ async function yieldResults(url, { signal, responseKeyName, totalRequestSize, on
                 newUrl = formatUrl(url, token);
                 yieldRequestHistory.next();
             } else {
-                yieldRequestHistory.return();
-
-                return [];
+                stop = true;
             }
 
             if (aborted(signal) || count >= totalRequestSize) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -165,7 +165,7 @@ async function yieldResults(url, options) {
         return [];
     }
 
-    const yieldRequestHistory = getHistoryYieldRequest(url, signal);
+    const yieldRequestHistory = getHistoryYieldRequest(signal);
     let count = 0;
     let stop = false;
     let newUrl = url;
@@ -208,15 +208,13 @@ async function yieldResults(url, options) {
 
 }
 
-function getHistoryYieldRequest(originalUrl, signal) {
+function getHistoryYieldRequest(signal) {
 
     function* yieldRequestHistory() {
-        let url = originalUrl;
+        let url = true;
 
-        while (url) {
-            if (url !== originalUrl) {
-                url = yield;
-            }
+        while () {
+            url = yield;
             yield fetch(encodeURI(url, { signal}))
                 .then(res => res.json());
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -201,28 +201,20 @@ async function yieldResults(url, options) {
         }
     }
 
+    yieldRequestHistory.return(false);
+
     return [];
 
 }
 
 function getHistoryYieldRequest(signal) {
 
-    async function* yieldRequestHistory() {
-        let proceed = true;
+    function* yieldRequestHistory() {
+        const url = yield;
 
-        while (proceed) {
-            let url = yield;
-            console.log('url', url);
+        while (url) {
             yield fetch(encodeURI(url, { signal}))
-                .then(res => res.json())
-                .then(res => {
-                    console.log('res', res);
-                    if (!res.continuationToken) {
-                        proceed = false;
-                    }
-
-                    return res;
-                });
+                .then(res => res.json());
         }
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -213,10 +213,11 @@ function getHistoryYieldRequest(signal) {
     function* yieldRequestHistory() {
         let url = yield;
 
-        while (url) {
+        do {
             yield fetch(encodeURI(url, { signal}))
                 .then(res => res.json());
-        }
+            url = yield;
+        } while (url);
     }
 
     const generator = yieldRequestHistory();

--- a/src/utils.js
+++ b/src/utils.js
@@ -152,14 +152,7 @@ function accumulateResults(url, options, property, soFar, totalLimit, token) {
     });
 }
 
-async function yieldResults(url, options) {
-    let {
-        signal,
-        responseKeyName,
-        totalRequestSize,
-        yieldRequestProcessor,
-        formatter
-    } = options;
+async function yieldResults(url, { signal, responseKeyName, totalRequestSize, onPartialReponse, formatter }) {
 
     if (aborted(signal)) {
         return [];
@@ -184,7 +177,7 @@ async function yieldResults(url, options) {
             formattedData = formatter(data);
 
             if (token) {
-                yieldRequestProcessor(formattedData);
+                onPartialReponse(formattedData);
                 newUrl = addTokenToUrl(url, token);
                 yieldRequestHistory.next();
             } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -220,7 +220,7 @@ function formatUrl(url, token) {
         return urlObject.toString();
     }
 
-    return urlObject;
+    return urlObject.toString();
 }
 
 function aborted(signal) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -191,7 +191,7 @@ async function yieldResults(url, options) {
             count += data.length;
             token = result.continuationToken;
             console.log('yield req proc', yieldRequestProcessor);
-            console.log('um', yieldRequestProcessor.next(formatter(data)));
+            console.log('um', yieldRequestProcessor().next(formatter(data)));
 
             if ((signal && signal.aborted) || !token || count >= totalRequestSize) {
                 console.log('stopping', signal, signal.aborted, token, count, totalRequestSize);

--- a/src/utils.js
+++ b/src/utils.js
@@ -176,12 +176,12 @@ async function yieldResults(url, options) {
 
     while (!stop) {
         result = await yieldRequestHistory.next(newUrl).value;
-        console.log('result', result);
         data = result[responseKeyName];
 
         if (data) {
             count += data.length;
             token = result.continuationToken;
+            console.log('token', token);
             formattedData = formatter(data);
 
             if (token) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -213,7 +213,7 @@ function getHistoryYieldRequest(signal) {
     function* yieldRequestHistory() {
         let url = true;
 
-        while () {
+        while (url) {
             url = yield;
             yield fetch(encodeURI(url, { signal}))
                 .then(res => res.json());

--- a/src/utils.js
+++ b/src/utils.js
@@ -163,7 +163,7 @@ function yieldResults(url, options) {
     } = options;
 
     if (aborted(signal)) {
-        return;
+        return [];
     }
 
     const yieldRequestHistory = getHistoryYieldRequest();
@@ -200,6 +200,8 @@ function yieldResults(url, options) {
             stop = true;
         }
     }
+
+    return [];
 
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -221,11 +221,10 @@ function getHistoryYieldRequest(signal) {
 
 function addTokenToUrl(url, token) {
     if (token !== undefined) {
-        if (url.indexOf('?') < 0) {
-            return url += '?next=' + token;
-        } else {
-            return url += '&next=' + token;
-        }
+        const urlObject = new URL(url);
+        urlObject.searchParams.set("next", token);
+
+        return urlObject.toString();
     }
 
     return url;

--- a/src/utils.js
+++ b/src/utils.js
@@ -187,6 +187,7 @@ async function yieldResults(url, options) {
             if (token) {
                 yieldRequestProcessor(formattedData);
                 newUrl = addTokenToUrl(url, token);
+                console.log('new url', newUrl);
             } else {
                 return formattedData;
             }
@@ -208,7 +209,7 @@ function getHistoryYieldRequest(signal) {
 
     function* yieldRequestHistory() {
         const url = yield;
-
+        console.log('yielded url', url);
         yield fetch(encodeURI(url, { signal})).then(res => res.json());
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -213,11 +213,13 @@ function getHistoryYieldRequest(originalUrl, signal) {
     function* yieldRequestHistory() {
         let url = originalUrl;
 
-        do {
+        while (url) {
+            if (url !== originalUrl) {
+                url = yield;
+            }
             yield fetch(encodeURI(url, { signal}))
                 .then(res => res.json());
-            url = yield;
-        } while (url);
+        }
     }
 
     const generator = yieldRequestHistory();

--- a/src/utils.js
+++ b/src/utils.js
@@ -137,7 +137,7 @@ function accumulateResults(url, options, property, soFar, totalLimit, token) {
 
     let newUrl = addTokenToUrl(url, token);
 
-    const result = fetch(encodeURI(newUrl), options)
+    const result = fetch(newUrl, options)
         .then(res => res.json());
 
     return result.then(res => {
@@ -161,7 +161,7 @@ async function yieldResults(url, { signal, responseKeyName, totalRequestSize, on
     const yieldRequestHistory = getHistoryYieldRequest(signal);
     let count = 0;
     let stop = false;
-    let newUrl = url;
+    let newUrl = addTokenToUrl(url);
     let token;
     let result;
     let data;
@@ -220,14 +220,15 @@ function getHistoryYieldRequest(signal) {
 }
 
 function addTokenToUrl(url, token) {
+    const urlObject = new URL(url);
+
     if (token !== undefined) {
-        const urlObject = new URL(url);
         urlObject.searchParams.set("next", token);
 
         return urlObject.toString();
     }
 
-    return url;
+    return urlObject;
 }
 
 function aborted(signal) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -175,7 +175,7 @@ function yieldResults(url, options) {
     let formattedData;
 
     while (!stop) {
-        result = yieldRequestHistory.next(newUrl);
+        result = yieldRequestHistory.next(newUrl).value;
         console.log('result', result);
         data = result[responseKeyName];
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -208,7 +208,7 @@ function getHistoryYieldRequest(signal) {
 
         while (url) {
             url = yield;
-            yield fetch(encodeURI(url, { signal}))
+            yield fetch(url, { signal})
                 .then(res => res.json());
         }
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -159,7 +159,7 @@ function accumulateResults(url, options, property, soFar, totalLimit, token) {
     });
 }
 
-yieldResults(url, options, property, totalLimit, yieldCallback) {
+function yieldResults(url, options, property, totalLimit, yieldCallback) {
     if (options.signal && options.signal.aborted) {
         return [];
     }
@@ -188,5 +188,6 @@ export {
     qualifiedNameToId,
     getValue,
     accumulateResults,
-    addLimitInformation
+    addLimitInformation,
+    yieldResults
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -135,10 +135,6 @@ function accumulateResults(url, options, property, soFar, totalLimit, token) {
         return [];
     }
 
-    if (totalLimit === undefined) {
-        totalLimit = 1000000;
-    }
-
     let newUrl = url;
     if (token !== undefined) {
         if (url.indexOf('?') < 0) {
@@ -161,6 +157,13 @@ function accumulateResults(url, options, property, soFar, totalLimit, token) {
         return accumulateResults(url, options, property, soFar, totalLimit,
             res.continuationToken);
     });
+}
+
+yieldResults(url, options, property, totalLimit, yieldCallback) {
+    if (options.signal && options.signal.aborted) {
+        return [];
+    }
+
 }
 
 /*

--- a/src/utils.js
+++ b/src/utils.js
@@ -190,8 +190,8 @@ async function yieldResults(url, options) {
         if (data) {
             count += data.length;
             token = result.continuationToken;
-
-            yieldRequestProcessor.next(formatter(data));
+            console.log('yield req proc', yieldRequestProcessor);
+            console.log('um', yieldRequestProcessor.next(formatter(data)));
 
             if ((signal && signal.aborted) || !token || count >= totalRequestSize) {
                 console.log('stopping', signal, signal.aborted, token, count, totalRequestSize);

--- a/src/utils.js
+++ b/src/utils.js
@@ -189,7 +189,7 @@ async function yieldResults(url, options) {
         console.log({data});
         if (data) {
             count += data.length;
-            token = data.continuationToken;
+            token = result.continuationToken;
 
             yieldRequestProcessor.next(formatter(data));
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -175,6 +175,7 @@ async function yieldResults(url, options) {
     let formattedData;
 
     while (!stop) {
+        console.log('url sent into yield req hist', newUrl);
         result = await yieldRequestHistory.next(newUrl).value;
         data = result[responseKeyName];
 
@@ -210,7 +211,7 @@ async function yieldResults(url, options) {
 function getHistoryYieldRequest(signal) {
 
     function* yieldRequestHistory() {
-        const url = yield;
+        let url = yield;
 
         while (url) {
             yield fetch(encodeURI(url, { signal}))

--- a/src/utils.js
+++ b/src/utils.js
@@ -181,7 +181,10 @@ async function yieldResults(url, { signal, responseKeyName, totalRequestSize, on
                 newUrl = addTokenToUrl(url, token);
                 yieldRequestHistory.next();
             } else {
-                return formattedData;
+                onPartialResponse(formattedData);
+                yieldRequestHistory.return(false);
+
+                return [];
             }
 
             if (aborted(signal) || count >= totalRequestSize) {


### PR DESCRIPTION
Need to have functionality to "yield" process telemetry if a processing method is provided in the options sent from Open MCT. If the method exists, the telemetry should be retrieved (1000 at a time due to YAMCS limits) and processed on each response and yielding control at that point until the next response (if available) comes back.

closes #80 
depends on #77 (77 should be merged first)