### PR TITLE
[Historical Provider] Request options being mutated

### DIFF
--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -50,7 +50,7 @@ export default class YamcsHistoricalTelemetryProvider {
     }
 
     request(domainObject, options) {
-        console.log('request options', {...options});
+        options = { ...options };
         this.standardizeOptions(options, domainObject);
         console.log('request standardized options', {...options});
         let id = domainObject.identifier.key;

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -50,10 +50,12 @@ export default class YamcsHistoricalTelemetryProvider {
     }
 
     request(domainObject, options) {
+        console.log('request options', {...options});
         this.standardizeOptions(options, domainObject);
-
+        console.log('request standardized options', {...options});
         let id = domainObject.identifier.key;
         let url = this.buildUrl(id, options);
+        console.log('request url', url);
         let requestArguments = [id, url, options];
         let isMinMax = !this.isImagery(domainObject)
             && domainObject.type !== OBJECT_TYPES.AGGREGATE_TELEMETRY_TYPE

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -52,10 +52,9 @@ export default class YamcsHistoricalTelemetryProvider {
     request(domainObject, options) {
         options = { ...options };
         this.standardizeOptions(options, domainObject);
-        console.log('request standardized options', {...options});
+
         let id = domainObject.identifier.key;
         let url = this.buildUrl(id, options);
-        console.log('request url', url);
         let requestArguments = [id, url, options];
         let isMinMax = !this.isImagery(domainObject)
             && domainObject.type !== OBJECT_TYPES.AGGREGATE_TELEMETRY_TYPE


### PR DESCRIPTION
Need to copy in the request options as we make changes to them. If not, causes incorrect data.

closes #84 