### PR TITLE
adding iso format for event utc metadata

### DIFF
--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -88,6 +88,7 @@ export default class YamcsObjectProvider {
                         key: 'utc',
                         source: 'generationTime',
                         name: 'Generation Time',
+                        format: 'iso',
                         hints: {
                             domain: 1
                         }


### PR DESCRIPTION
Added ISO formatter for Event date metadata.

closes #87 

## Testing
- Verify when viewing events, the browser doesn't lock up