### PR TITLE
Update example plugin paths

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -25,8 +25,8 @@ const openmct = window.openmct;
         openmct.install(openmct.plugins.LocalStorage());
         openmct.install(openmct.plugins.Espresso());
         openmct.install(openmct.plugins.MyItems());
-        openmct.install(openmct.plugins.Generator());
-        openmct.install(openmct.plugins.ExampleImagery());
+        openmct.install(openmct.plugins.example.Generator());
+        openmct.install(openmct.plugins.example.ExampleImagery());
         openmct.install(openmct.plugins.UTCTimeSystem());
         openmct.install(openmct.plugins.TelemetryMean());
 


### PR DESCRIPTION
This will fix any errors from the plugins being moved into their own `example` object.

closes #97 