### PR TITLE
[CI] Add Basic CI and github templates from nasa/openmct

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: File a Bug !
+title: ''
+labels: type:bug
+assignees: ''
+
+---
+
+<!--- Focus on user impact in the title. Use the Summary Field to -->
+<!--- describe the problem technically. -->
+
+#### Summary
+<!--- A description of the issue encountered. When possible, a description -->
+<!--- of the impact of the issue. What use case does it impede?-->
+
+#### Expected vs Current Behavior
+<!--- Tell us what should have happened -->
+
+#### Impact Check List
+<!--- Please select from the following options -->
+
+- [ ] Data loss or misrepresented data?
+- [ ] Regression? Did this used to work or has it always been broken?
+- [ ] Is there a workaround available?
+- [ ] Does this impact a critical component?
+- [ ] Is this just a visual bug with no functional impact?
+
+#### Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+#### Environment
+* Open MCT Version: <!--- date of build, version, or SHA -->
+* Deployment Type: <!--- npm dev? VIPER Dev? openmct-yamcs? -->
+* OS:
+* Browser:
+
+#### Additional Information
+<!--- Include any screenshots, gifs, or logs which will expedite triage -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions
+    url: https://github.com/nasa/openmct/discussions
+    about: Have a question about the project?

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -1,0 +1,20 @@
+---
+name: Enhancement request
+about: Suggest an enhancement or new improvement for this project
+title: ''
+labels: type:enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/maintenance-type.md
+++ b/.github/ISSUE_TEMPLATE/maintenance-type.md
@@ -1,0 +1,11 @@
+---
+name: Maintenance
+about: Add, update or remove documentation, tests, or dependencies.
+title: ''
+labels: type:maintenance
+assignees: ''
+
+---
+
+#### Summary
+<!--- Generally describe the purpose of the change. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--- Note: Please open the PR in draft form until you are ready for active review. -->
+Closes <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->
+
+### Describe your changes:
+<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
+
+### All Submissions:
+
+* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
+* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
+* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.
+
+### Author Checklist
+
+* [ ] Changes address original issue?
+* [ ] Unit tests included and/or updated with changes?
+* [ ] Command line build passes?
+* [ ] Has this been smoke tested?
+* [ ] Testing instructions included in associated issue?
+
+### Reviewer Checklist
+
+* [ ] Changes appear to address issue?
+* [ ] Changes appear not to be breaking changes?
+* [ ] Appropriate unit tests included?
+* [ ] Code style and in-line documentation are appropriate?
+* [ ] Commit messages meet standards?
+* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
+* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"  
+    open-pull-requests-limit: 4
+    labels:
+      - "type:maintenance"
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"    
+    labels:
+      - "type:maintenance"
+      - "dependencies"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,4 +27,4 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm install
-    
+    - run: npm start

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm install
+    


### PR DESCRIPTION
We had a recent regression which would have been found with basic `npm install` + `npm start`. This PR adds basic CI for node 12, 14, and 16.
Also includes a copy of some of the templates from nasa/openmct