### PR TITLE
[CI] Add release branch for 1.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct-yamcs",
-  "version": "1.6.2",
+  "version": "1.8.5-SNAPSHOT",
   "description": "An adapter for connecting Open MCT with YAMCS",
   "main": "dist/openmct-yamcs.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct-yamcs",
-  "version": "1.8.5-SNAPSHOT",
+  "version": "1.8.5",
   "description": "An adapter for connecting Open MCT with YAMCS",
   "main": "dist/openmct-yamcs.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.10.3"
+  },
+  "peerDependencies": {
+    "openmct": "nasa/openmct#release/1.8.5"
   }
 }


### PR DESCRIPTION
This adds a release branch for openmct-yamcs for 1.8.5. Pins to supported openmct as a peerDependency