### PR TITLE
Fix webpack config so that openmct-yamcs can be used as a library

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,9 +37,11 @@ const WEBPACK_CONFIG = {
     },
     mode: 'production',
     output: {
-        filename: '[name].js',
+	globalObject: "this",
+	filename: '[name].js',
         path: path.resolve(__dirname, 'dist'),
-        libraryTarget: 'umd'
+        libraryTarget: 'umd',
+	library: 'openmctYamcs'
     },
     devtool: devMode ? 'eval-source-map' : 'source-map',
     devServer: {


### PR DESCRIPTION
Fixes https://github.com/akhenry/openmct-yamcs/issues/104.

This fixes the webpack config to produce a named library that can actually be referenced from including code. Currently we are including openmct-yamcs by building into into our binaries from source using webpack, which bypasses the library `output` configuration altogether, so we've never noticed that `openmct-yamcs` can't actually be used as a library.

Per [the webpack docs](https://webpack.js.org/configuration/output/#type-umd), a library name is required for `umd` build types.