### PR TITLE
Better handling of latest parameter values when no data is available

### DIFF
--- a/src/providers/realtime-provider.js
+++ b/src/providers/realtime-provider.js
@@ -192,7 +192,7 @@ export default class RealtimeProvider {
 
                 // only event is handled differently
                 if (this.isTelemetryMessage(data)) {
-                    let values = data.data.values;
+                    let values = data.data.values || [];
                     let parentName = subscriptionDetails.domainObject.name;
 
                     values.forEach(parameter => {
@@ -269,7 +269,7 @@ export default class RealtimeProvider {
     }
 
     isTelemetryMessage(message) {
-        return message.data.values;
+        return message.type === 'parameters';
     }
 
 }


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes https://github.com/nasa/openmct/issues/5385

### Describe your changes:
This bug was due to a recent unrelated change in our parameter subscriptions which means that Yamcs now sends us back the latest value for a parameter immediately. If Yamcs has nothing in its latest data table (because no parameter value has been received since the last restart) then Yamcs will return an slightly different response, which was being incorrectly interpreted as a telemetry value.

Note that fixing this issue unearthed [another problem](https://github.com/nasa/openmct/issues/5424), which I have also fixed in a separate PR.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Commit messages meet standards?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
