### PR TITLE
Return yamcs search results

### DIFF
--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -140,6 +140,10 @@ export default class YamcsObjectProvider {
         });
     }
 
+    supportsSearchType(type) {
+        return type === this.openmct.objects.SEARCH_TYPES.OBJECTS;
+    }
+
     search(query, options) {
         const spaceSystemsSearch = this.searchMdbApi('space-systems', query, options);
         const parametersSearch = this.searchMdbApi('parameters', query, options);


### PR DESCRIPTION
Closes https://github.com/akhenry/openmct-yamcs/issues/162

### Describe your changes:
Small change to the Yamcs object provider so that it reports which types of searches it supports to the Open MCT search API.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
