### PR TITLE
Handle absent enumValue property for enumerated types

### DIFF
--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -376,7 +376,7 @@ export default class YamcsObjectProvider {
 
             if (this.isEnumeration(parameter)) {
                 telemetryValue.format = 'enum';
-                const yamcsEnumerations = parameter.type.enumValue;
+                const yamcsEnumerations = parameter.type.enumValue || [];
                 telemetryValue.enumerations = yamcsEnumerations.map(enumValue => {
                     let rawValue = enumValue.value;
 


### PR DESCRIPTION
Closes #161 

### Describe your changes:
Set enumerations to an empty array if the `enumValue` property is absent

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
