### PR TITLE
Batch multiple requests for latest values

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -42,7 +42,8 @@ export default function installYamcsPlugin(configuration) {
 
         const latestTelemetryProvider = new LatestTelemetryProvider({
             url: configuration.yamcsHistoricalEndpoint,
-            instance: configuration.yamcsInstance
+            instance: configuration.yamcsInstance,
+            openmct
         });
 
         const historicalTelemetryProvider = new YamcsHistoricalTelemetryProvider(


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes https://github.com/nasa/openmct/issues/5193

### Describe your changes:
Small change to how the latest value is fetched for operator status. Multiple requests in succession will now be batched and use [the batch get capability in the Yamcs API](https://docs.yamcs.org/yamcs-http-api/processing/batch-get-parameter-values/).

This addresses two issues which may have been causing the [issues reported in testing](https://github.com/nasa/openmct/issues/5193#issuecomment-1176548294):
1. Requests to get parameter values were periodically resulting in a 403 error, which appeared to be completely spurious. The parameters affected were random, and the issue was transient. An error while fetching parameter values could result in the operator status summary screen being out of sync
2. Batching requests results in fewer overall requests, which improves lag due to blocking HTTP requests, which may have been contributing to the observed issues.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
