### PR TITLE
Do not use the parameter archive for `latest` type requests in real-time mode

### DIFF
--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -55,12 +55,10 @@ export default class YamcsHistoricalTelemetryProvider {
         options = { ...options };
         this.standardizeOptions(options, domainObject);
         if ((options.strategy === 'latest') && options.timeContext?.isRealtime()) {
-            console.debug(`🍇 Latest requested in realtime, using cached websocket data`);
-
+            // Latest requested in realtime, use cached websocket data
             return [];
-        } else {
-            console.debug(`🍑 In historical or fixed time mode`);
         }
+        // otherwise we're in fixed time mode or historical
 
         const id = domainObject.identifier.key;
         const hasEnumValue = this.hasEnumValue(domainObject);

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -54,7 +54,7 @@ export default class YamcsHistoricalTelemetryProvider {
     request(domainObject, options) {
         options = { ...options };
         this.standardizeOptions(options, domainObject);
-        if ((options.strategy === 'latest') && options.timeContext?.isRealtime) {
+        if ((options.strategy === 'latest') && options.timeContext?.isRealtime()) {
             console.debug(`🍇 Latest requested in realtime, using cached websocket data`);
 
             return [];

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -54,8 +54,7 @@ export default class YamcsHistoricalTelemetryProvider {
     request(domainObject, options) {
         options = { ...options };
         this.standardizeOptions(options, domainObject);
-        const isRealtime = this.openmct.time.clock();
-        if ((options.strategy === 'latest') && isRealtime) {
+        if ((options.strategy === 'latest') && options.timeContext?.isRealtime) {
             console.debug(`🍇 Latest requested in realtime, using cached websocket data`);
 
             return [];

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -54,7 +54,7 @@ export default class YamcsHistoricalTelemetryProvider {
     request(domainObject, options) {
         options = { ...options };
         this.standardizeOptions(options, domainObject);
-        if ((options.strategy === 'latest') && options.timeContext?.isRealtime()) {
+        if ((options.strategy === 'latest') && options.timeContext?.isRealTime()) {
             // Latest requested in realtime, use cached websocket data
             return [];
         }

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -54,6 +54,14 @@ export default class YamcsHistoricalTelemetryProvider {
     request(domainObject, options) {
         options = { ...options };
         this.standardizeOptions(options, domainObject);
+        const isRealtime = this.openmct.time.clock();
+        if ((options.strategy === 'latest') && isRealtime) {
+            console.debug(`🍇 Latest requested in realtime, using cached websocket data`);
+
+            return [];
+        } else {
+            console.debug(`🍑 In historical or fixed time mode`);
+        }
 
         const id = domainObject.identifier.key;
         const hasEnumValue = this.hasEnumValue(domainObject);

--- a/tests/e2e/yamcs/network.e2e.spec.js
+++ b/tests/e2e/yamcs/network.e2e.spec.js
@@ -1,0 +1,93 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2022, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+/*
+Network Specific Tests
+*/
+
+const { test, expect } = require('../opensource/pluginFixtures');
+
+test.describe("Quickstart network requests @yamcs", () => {
+    // Collect all request events, specifically for YAMCS
+    let networkRequests = [];
+
+    test('Validate network traffic to YAMCS', async ({ page }) => {
+        page.on('request', (request) => networkRequests.push(request));
+        // Go to baseURL
+        await page.goto("./", { waitUntil: "networkidle" });
+
+        await expandTreePaneItemByName(page, 'myproject');
+        await expandTreePaneItemByName(page, 'myproject');
+
+        networkRequests = [];
+        await page.locator('text=CCSDS_Packet_Sequence').click();
+        await page.waitForLoadState('networkidle');
+        // Network requests should be zero in real-time mode (using websocket cache)
+        expect(filterNonFetchRequests(networkRequests).length).toBe(0);
+
+        networkRequests = [];
+        await page.locator('text=CCSDS_Packet_Length').click();
+        await page.waitForLoadState('networkidle');
+        // Network requests are:
+        // 1. Limit request from parameter archive
+        // 2. Telemetry from parameter archive
+        expect(filterNonFetchRequests(networkRequests).length).toBe(2);
+
+        // Change to fixed time
+        await page.locator('button:has-text("Local Clock")').click();
+        await page.locator('text="Fixed Timespan"').click();
+
+        networkRequests = [];
+        await page.locator('text=CCSDS_Packet_Sequence').click();
+        await page.waitForLoadState('networkidle');
+        // Should now fetch from parameter archive, so two requests, one for each item in the aggregate
+        console.debug('🥕', filterNonFetchRequests(networkRequests));
+        expect(filterNonFetchRequests(networkRequests).length).toBe(2);
+
+        await page.locator('text=CCSDS_Packet_Length').click();
+        await page.waitForLoadState('networkidle');
+        // Network requests should remain the same in fixed time:
+        // 1. Limit request from parameter archive
+        // 2. Telemetry from parameter archive
+        expect(filterNonFetchRequests(networkRequests).length).toBe(2);
+
+    });
+
+    // Try to reduce indeterminism of browser requests by only returning fetch requests.
+    // Filter out preflight CORS, fetching stylesheets, page icons, etc. that can occur during tests
+    function filterNonFetchRequests(requests) {
+        return requests.filter(request => {
+            return (request.resourceType() === 'fetch');
+        });
+    }
+});
+
+/**
+ * @param {import('@playwright/test').Page} page
+ * @param {string} name
+ */
+async function expandTreePaneItemByName(page, name) {
+    const treePane = page.locator('#tree-pane');
+    const treeItem = treePane.locator(`role=treeitem[expanded=false][name=/${name}/]`);
+    const expandTriangle = treeItem.locator('.c-disclosure-triangle');
+    await expandTriangle.click();
+}

--- a/tests/e2e/yamcs/network.e2e.spec.js
+++ b/tests/e2e/yamcs/network.e2e.spec.js
@@ -60,7 +60,6 @@ test.describe("Quickstart network requests @yamcs", () => {
         await page.locator('text=CCSDS_Packet_Sequence').click();
         await page.waitForLoadState('networkidle');
         // Should now fetch from parameter archive, so two requests, one for each item in the aggregate
-        console.debug('🥕', filterNonFetchRequests(networkRequests));
         expect(filterNonFetchRequests(networkRequests).length).toBe(2);
 
         await page.locator('text=CCSDS_Packet_Length').click();

--- a/tests/e2e/yamcs/network.e2e.spec.js
+++ b/tests/e2e/yamcs/network.e2e.spec.js
@@ -26,7 +26,7 @@ Network Specific Tests
 
 const { test, expect } = require('../opensource/pluginFixtures');
 
-test.describe("Quickstart network requests @yamcs", () => {
+test.describe.only("Quickstart network requests @yamcs", () => {
     // Collect all request events, specifically for YAMCS
     let networkRequests = [];
 
@@ -62,6 +62,7 @@ test.describe("Quickstart network requests @yamcs", () => {
         // Should now fetch from parameter archive, so two requests, one for each item in the aggregate
         expect(filterNonFetchRequests(networkRequests).length).toBe(2);
 
+        networkRequests = [];
         await page.locator('text=CCSDS_Packet_Length').click();
         await page.waitForLoadState('networkidle');
         // Network requests should remain the same in fixed time:

--- a/tests/e2e/yamcs/network.e2e.spec.js
+++ b/tests/e2e/yamcs/network.e2e.spec.js
@@ -26,7 +26,7 @@ Network Specific Tests
 
 const { test, expect } = require('../opensource/pluginFixtures');
 
-test.describe.only("Quickstart network requests @yamcs", () => {
+test.describe("Quickstart network requests @yamcs", () => {
     // Collect all request events, specifically for YAMCS
     let networkRequests = [];
 


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #139 

### Describe your changes:
In the historical telemetry provider, if we're asking for `latest` and we're in real-time, use the cached websocket value instead of asking the parameter archive.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
