### PR TITLE
Get limits from MDB dicitionary load instead of parameter archive

### DIFF
--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -410,7 +410,7 @@ export default class YamcsObjectProvider {
                 telemetryValue.enumerations = yamcsEnumerations.map(enumValue => {
                     let rawValue = enumValue.value;
 
-                    if (!(Number.isNaN(rawValue))) {
+                    if (!(isNaN(rawValue))) {
                         // eslint-disable-next-line radix
                         rawValue = parseInt(rawValue);
                     }

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -29,6 +29,7 @@ import { OBJECT_TYPES, NAMESPACE } from '../const';
 import OperatorStatusParameter from './user/operator-status-parameter.js';
 import { createCommandsObject } from './commands.js';
 import { createEventsObject } from './events.js';
+import limitConfig from "../limits-config.json";
 
 const YAMCS_API_MAP = {
     'space-systems': 'spaceSystems',
@@ -42,11 +43,11 @@ export default class YamcsObjectProvider {
         this.url = url;
         this.instance = instance;
         this.folderName = folderName;
-        this.dictionary = undefined;
+        this.dictionary = null;
         this.namespace = NAMESPACE;
         this.key = 'spacecraft';
         this.objects = {};
-        this.dictionaryPromise = undefined;
+        this.dictionaryPromise = null;
         this.roleStatusTelemetry = roleStatusTelemetry;
         this.pollQuestionParameter = pollQuestionParameter;
         this.pollQuestionTelemetry = pollQuestionTelemetry;
@@ -59,8 +60,8 @@ export default class YamcsObjectProvider {
         const eventsObject = createEventsObject(this.openmct, this.key, this.namespace);
         const commandsObject = createCommandsObject(this.openmct, this.key, this.namespace);
 
-        this.addObject(commandsObject);
-        this.addObject(eventsObject);
+        this.#addObject(commandsObject);
+        this.#addObject(eventsObject);
         this.rootObject.composition.push(
             eventsObject.identifier,
             commandsObject.identifier
@@ -79,7 +80,7 @@ export default class YamcsObjectProvider {
             composition: []
         };
 
-        this.addObject(this.rootObject);
+        this.#addObject(this.rootObject);
     }
 
     async get(identifier) {
@@ -90,7 +91,7 @@ export default class YamcsObjectProvider {
         }
 
         // Otherwise, return a telemetry object from the telemetry dictionary
-        const dictionary = await this.getTelemetryDictionary();
+        const dictionary = await this.#getTelemetryDictionary();
 
         return dictionary[key];
     }
@@ -100,8 +101,8 @@ export default class YamcsObjectProvider {
     }
 
     async search(query, options) {
-        const spaceSystemsSearch = this.searchMdbApi('space-systems', query, options);
-        const parametersSearch = this.searchMdbApi('parameters', query, options);
+        const spaceSystemsSearch = this.#searchMdbApi('space-systems', query, options);
+        const parametersSearch = this.#searchMdbApi('parameters', query, options);
 
         const [spaceSystemsResults, parametersResults] = await Promise.all([spaceSystemsSearch, parametersSearch]);
 
@@ -142,9 +143,9 @@ export default class YamcsObjectProvider {
         return telemetries;
     }
 
-    async searchMdbApi(operation, query, options) {
+    async #searchMdbApi(operation, query, options) {
         const key = YAMCS_API_MAP[operation];
-        const search = await this.fetchMdbApi(`${operation}?q=${query}&searchMembers=true&details=false`);
+        const search = await this.#fetchMdbApi(`${operation}?q=${query}&searchMembers=true&details=false`);
         const hits = search[key];
 
         if (!hits) {
@@ -153,7 +154,7 @@ export default class YamcsObjectProvider {
 
         // make sure we have the dictionary loaded first
         // even though calling get will fetch dictionary if not already loaded
-        await this.getTelemetryDictionary();
+        await this.#getTelemetryDictionary();
 
         // if multiple members match, YAMCS sends us duplicates 🙇‍♂️
         const hitsWithoutDupes = [];
@@ -179,24 +180,24 @@ export default class YamcsObjectProvider {
         return flattenedResults;
     }
 
-    async getTelemetryDictionary() {
-        if (this.dictionary !== undefined) {
-            return Promise.resolve(this.dictionary);
+    async #getTelemetryDictionary() {
+        if (this.dictionary) {
+            return this.dictionary;
         }
 
-        const dictionary = await this.fetchTelemetryDictionary(this.url, this.instance, this.folderName);
+        const dictionary = await this.#fetchTelemetryDictionary(this.url, this.instance, this.folderName);
         this.dictionary = dictionary;
         this.roleStatusTelemetry.dictionaryLoadComplete();
 
         return dictionary;
     }
 
-    async fetchTelemetryDictionary() {
+    async #fetchTelemetryDictionary() {
         const operation = 'parameters?details=yes&limit=1000';
         const parameterUrl = this.url + 'api/mdb/' + this.instance + '/' + operation;
 
-        if (this.dictionaryPromise === undefined) {
-            let url = this.getMdbUrl('space-systems');
+        if (!this.dictionaryPromise) {
+            let url = this.#getMdbUrl('space-systems');
             const spaceSystems = this.dictionaryPromise = await accumulateResults(url, {}, 'spaceSystems', []);
 
             const parameters = await accumulateResults(parameterUrl, {}, 'parameters', []);
@@ -206,14 +207,14 @@ export default class YamcsObjectProvider {
                 return a.name.localeCompare(b.name);
             });
             spaceSystems.forEach(spaceSystem => {
-                this.addSpaceSystem(spaceSystem);
+                this.#addSpaceSystem(spaceSystem);
             });
 
             parameters.forEach(parameter => {
-                this.addParameterObject(parameter);
+                this.#addParameterObject(parameter);
             });
 
-            this.dictionaryPromise = undefined;
+            this.dictionaryPromise = null;
 
             return this.objects;
         }
@@ -221,11 +222,11 @@ export default class YamcsObjectProvider {
         return this.dictionaryPromise;
     }
 
-    getMdbUrl(operation, name = '') {
+    #getMdbUrl(operation, name = '') {
         return this.url + 'api/mdb/' + this.instance + '/' + operation + name;
     }
 
-    async fetchMdbApi(operation, name = '') {
+    async #fetchMdbApi(operation, name = '') {
         const mdbURL = `${this.url}api/mdb/${this.instance}/${operation}${name}`;
         const response = await fetch(mdbURL);
         const parsedJSON = await response.json();
@@ -233,11 +234,11 @@ export default class YamcsObjectProvider {
         return parsedJSON;
     }
 
-    addSpaceSystem(spaceSystem) {
+    #addSpaceSystem(spaceSystem) {
         if (spaceSystem.qualifiedName !== '/') {
             let composition = [];
 
-            if (spaceSystem.sub !== undefined) {
+            if (spaceSystem.sub) {
                 /* Sort the subsidiary space systems by name. */
                 spaceSystem.sub.sort((a, b) => {
                     return a.name.localeCompare(b.name);
@@ -270,7 +271,7 @@ export default class YamcsObjectProvider {
                 location: location
             };
 
-            this.addObject(obj);
+            this.#addObject(obj);
 
             /* Add the space system to the root object if it's top-level. */
             if (spaceSystem.qualifiedName.lastIndexOf('/') === 0) {
@@ -282,7 +283,7 @@ export default class YamcsObjectProvider {
         }
     }
 
-    addObject(object) {
+    #addObject(object) {
         this.objects[object.identifier.key] = object;
     }
 
@@ -290,24 +291,50 @@ export default class YamcsObjectProvider {
      * Add a telemetry parameter object to the object tree, unless it
      * has an alias indicating to omit the parameter from OpenMCT.
      */
-    addParameterObject(parameter) {
-        if (!this.isSuppressed(parameter)) {
+    #addParameterObject(parameter) {
+        if (!this.#isSuppressed(parameter)) {
             let qn = parameter.qualifiedName;
             let lastSlashPos = qn.lastIndexOf('/');
             let parentId = qualifiedNameToId(qn.substring(0, lastSlashPos));
             let parent = this.objects[parentId];
 
-            this.addParameter(parameter, qn, parent, '');
+            this.#addParameter(parameter, qn, parent, '');
         }
     }
 
-    isSuppressed(parameter) {
+    #isSuppressed(parameter) {
         return (parameter.alias && parameter.alias.some(alias => {
             return (alias.namespace === 'OpenMCT:omit');
         }));
     }
 
-    addParameter(parameter, qualifiedName, parent, prefix) {
+    #getLimitFromAlarmRange(alarmRange) {
+        let limits = {};
+        alarmRange.forEach(alarm => {
+            limits[alarm.level] = {
+                low: {
+                    color: limitConfig[alarm.level],
+                    value: alarm.minInclusive || alarm.minExclusive
+                },
+                high: {
+                    color: limitConfig[alarm.level],
+                    value: alarm.maxInclusive || alarm.maxExclusive
+                }
+            };
+        });
+
+        return limits;
+    }
+
+    #convertToLimits(defaultAlarm) {
+        if (defaultAlarm?.staticAlarmRange) {
+            return this.#getLimitFromAlarmRange(defaultAlarm.staticAlarmRange);
+        } else {
+            throw new Error(`Passed alarm has invalid object syntax for limit conversion`, defaultAlarm);
+        }
+    }
+
+    #addParameter(parameter, qualifiedName, parent, prefix) {
         const id = qualifiedNameToId(qualifiedName);
         const name = prefix + parameter.name;
         const location = this.openmct.objects.makeKeyString({
@@ -319,9 +346,10 @@ export default class YamcsObjectProvider {
                 key: id,
                 namespace: this.namespace
             },
-            type: this.getParameterType(parameter),
+            type: this.#getParameterType(parameter),
             name: name,
             location: location,
+            configuration: {},
             telemetry: {
                 values: [{
                     key: 'utc',
@@ -334,8 +362,12 @@ export default class YamcsObjectProvider {
                 }]
             }
         };
-        const isAggregate = this.isAggregate(parameter);
+        const isAggregate = this.#isAggregate(parameter);
         let aggregateHasMembers = false;
+
+        if (parameter.type.defaultAlarm) {
+            obj.configuration.limits = this.#convertToLimits(parameter.type.defaultAlarm);
+        }
 
         if (!isAggregate) {
             const key = 'value';
@@ -356,7 +388,7 @@ export default class YamcsObjectProvider {
 
             if (operatorStatusParameter.isOperatorStatusParameter(parameter)) {
                 const role = operatorStatusParameter.getRoleFromParameter(parameter);
-                if (role === undefined) {
+                if (!role) {
                     throw new Error(`Operator Status Parameter "${parameter.qualifiedName}" does not specify a role`);
                 }
 
@@ -372,13 +404,13 @@ export default class YamcsObjectProvider {
                 telemetryValue.format = 'string';
             }
 
-            if (this.isEnumeration(parameter)) {
+            if (this.#isEnumeration(parameter)) {
                 telemetryValue.format = 'enum';
                 const yamcsEnumerations = parameter.type.enumValue || [];
                 telemetryValue.enumerations = yamcsEnumerations.map(enumValue => {
                     let rawValue = enumValue.value;
 
-                    if (!isNaN(rawValue)) {
+                    if (!Number.isNaN(rawValue)) {
                         // eslint-disable-next-line radix
                         rawValue = parseInt(rawValue);
                     }
@@ -392,17 +424,17 @@ export default class YamcsObjectProvider {
 
             obj.telemetry.values.push(telemetryValue);
 
-            this.addHints(key, obj);
+            this.#addHints(key, obj);
         } else {
-            aggregateHasMembers = this.aggregateHasMembers(parameter);
+            aggregateHasMembers = this.#aggregateHasMembers(parameter);
             obj.composition = [];
             if (aggregateHasMembers) {
-                let memberMetadata = this.formatAggregateMembers(parameter.type.member, name.replace('_', '.'));
+                let memberMetadata = this.#formatAggregateMembers(parameter.type.member, name.replace('_', '.'));
                 obj.telemetry.values = obj.telemetry.values.concat(memberMetadata);
             }
         }
 
-        this.addObject(obj);
+        this.#addObject(obj);
 
         parent.composition.push(obj.identifier);
 
@@ -410,12 +442,12 @@ export default class YamcsObjectProvider {
             parameter.type.member.forEach(member => {
                 const memberQualifiedName = qualifiedName + '.' + member.name;
                 /* Use current name as a prefix for the member name. */
-                this.addParameter(member, memberQualifiedName, obj, name + '_');
+                this.#addParameter(member, memberQualifiedName, obj, name + '_');
             });
         }
     }
 
-    addHints(key, obj) {
+    #addHints(key, obj) {
         const metadatum = obj.telemetry.values.find(md => md.key === key);
 
         if (obj.type === OBJECT_TYPES.STRING_OBJECT_TYPE) {
@@ -427,27 +459,27 @@ export default class YamcsObjectProvider {
 
     }
 
-    isAggregate(parameter) {
+    #isAggregate(parameter) {
         let isAggregate = false;
 
-        if (parameter.type !== undefined) {
+        if (parameter.type) {
             isAggregate = parameter.type.engType === 'aggregate';
         }
 
         return isAggregate;
     }
 
-    isEnumeration(parameter) {
+    #isEnumeration(parameter) {
         let isEnumeration = false;
 
-        if (parameter.type !== undefined) {
+        if (parameter.type) {
             isEnumeration = parameter.type.engType === 'enumeration';
         }
 
         return isEnumeration;
     }
 
-    formatAggregateMembers(members, parentKey = '', rangeHint = 1) {
+    #formatAggregateMembers(members, parentKey = '', rangeHint = 1) {
         let formatted = [];
 
         members.forEach(member => {
@@ -462,7 +494,7 @@ export default class YamcsObjectProvider {
                 }
             }
 
-            if (!this.isAggregate(member)) {
+            if (!this.#isAggregate(member)) {
                 formatted.push({
                     key,
                     name,
@@ -470,8 +502,8 @@ export default class YamcsObjectProvider {
                         range: rangeHint++
                     }
                 });
-            } else if (this.aggregateHasMembers(member)) {
-                let formattedSubMembers = this.formatAggregateMembers(member.type.member, key, rangeHint);
+            } else if (this.#aggregateHasMembers(member)) {
+                let formattedSubMembers = this.#formatAggregateMembers(member.type.member, key, rangeHint);
                 formatted = formatted.concat(formattedSubMembers);
             }
         });
@@ -479,30 +511,30 @@ export default class YamcsObjectProvider {
         return formatted;
     }
 
-    aggregateHasMembers(parameter) {
+    #aggregateHasMembers(parameter) {
         let hasMembers = false;
 
-        if (this.isAggregate(parameter)) {
-            hasMembers = parameter.type.member !== undefined;
+        if (this.#isAggregate(parameter) && parameter.type.member) {
+            hasMembers = true;
         }
 
         return hasMembers;
     }
 
-    getParameterType(parameter) {
+    #getParameterType(parameter) {
         for (let i in parameter.alias) {
             if (parameter.alias[i].namespace === 'OpenMCT:type') {
                 return parameter.alias[i].name;
             }
         }
 
-        if (this.isAggregate(parameter) && this.aggregateHasMembers(parameter)) {
+        if (this.#isAggregate(parameter) && this.#aggregateHasMembers(parameter)) {
             return OBJECT_TYPES.AGGREGATE_TELEMETRY_TYPE;
         }
 
         /* Built-in Yamcs telemetry does not supply type information. */
         if (
-            parameter.type === undefined
+            parameter.type
             || (parameter.type.engType === 'integer'
             || parameter.type.engType === 'float'
             || parameter.type.engType === 'enumeration')

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -410,7 +410,7 @@ export default class YamcsObjectProvider {
                 telemetryValue.enumerations = yamcsEnumerations.map(enumValue => {
                     let rawValue = enumValue.value;
 
-                    if (!Number.isNaN(rawValue)) {
+                    if (!(Number.isNaN(rawValue))) {
                         // eslint-disable-next-line radix
                         rawValue = parseInt(rawValue);
                     }
@@ -429,7 +429,7 @@ export default class YamcsObjectProvider {
             aggregateHasMembers = this.#aggregateHasMembers(parameter);
             obj.composition = [];
             if (aggregateHasMembers) {
-                let memberMetadata = this.#formatAggregateMembers(parameter.type.member, name.replace('_', '.'));
+                const memberMetadata = this.#formatAggregateMembers(parameter.type.member, name.replace('_', '.'));
                 obj.telemetry.values = obj.telemetry.values.concat(memberMetadata);
             }
         }
@@ -460,23 +460,11 @@ export default class YamcsObjectProvider {
     }
 
     #isAggregate(parameter) {
-        let isAggregate = false;
-
-        if (parameter.type) {
-            isAggregate = parameter.type.engType === 'aggregate';
-        }
-
-        return isAggregate;
+        return parameter?.type?.engType === 'aggregate';
     }
 
     #isEnumeration(parameter) {
-        let isEnumeration = false;
-
-        if (parameter.type) {
-            isEnumeration = parameter.type.engType === 'enumeration';
-        }
-
-        return isEnumeration;
+        return parameter?.type?.engType === 'enumeration';
     }
 
     #formatAggregateMembers(members, parentKey = '', rangeHint = 1) {
@@ -512,13 +500,7 @@ export default class YamcsObjectProvider {
     }
 
     #aggregateHasMembers(parameter) {
-        let hasMembers = false;
-
-        if (this.#isAggregate(parameter) && parameter.type.member) {
-            hasMembers = true;
-        }
-
-        return hasMembers;
+        return this.#isAggregate(parameter) && parameter.type.member;
     }
 
     #getParameterType(parameter) {

--- a/tests/e2e/yamcs/network.e2e.spec.js
+++ b/tests/e2e/yamcs/network.e2e.spec.js
@@ -1,0 +1,93 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2022, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+/*
+Network Specific Tests
+*/
+
+const { test, expect } = require('../opensource/pluginFixtures');
+
+test.describe("Quickstart network requests @yamcs", () => {
+    // Collect all request events, specifically for YAMCS
+    let networkRequests = [];
+
+    test('Validate network traffic to YAMCS', async ({ page }) => {
+        page.on('request', (request) => networkRequests.push(request));
+        // Go to baseURL
+        await page.goto("./", { waitUntil: "networkidle" });
+
+        await expandTreePaneItemByName(page, 'myproject');
+        await expandTreePaneItemByName(page, 'myproject');
+
+        networkRequests = [];
+        await page.locator('text=CCSDS_Packet_Sequence').click();
+        await page.waitForLoadState('networkidle');
+        // Network requests should be zero in real-time mode (using websocket cache)
+        expect(filterNonFetchRequests(networkRequests).length).toBe(0);
+
+        networkRequests = [];
+        await page.locator('text=CCSDS_Packet_Length').click();
+        await page.waitForLoadState('networkidle');
+        // Network requests are:
+        // 1. Limit request from parameter archive
+        // 2. Telemetry from parameter archive
+        expect(filterNonFetchRequests(networkRequests).length).toBe(2);
+
+        // Change to fixed time
+        await page.locator('button:has-text("Local Clock")').click();
+        await page.locator('text="Fixed Timespan"').click();
+
+        networkRequests = [];
+        await page.locator('text=CCSDS_Packet_Sequence').click();
+        await page.waitForLoadState('networkidle');
+        // Should now fetch from parameter archive, so two requests, one for each item in the aggregate
+        console.debug('🥕', filterNonFetchRequests(networkRequests));
+        expect(filterNonFetchRequests(networkRequests).length).toBe(2);
+
+        await page.locator('text=CCSDS_Packet_Length').click();
+        await page.waitForLoadState('networkidle');
+        // Network requests should remain the same in fixed time:
+        // 1. Limit request from parameter archive
+        // 2. Telemetry from parameter archive
+        expect(filterNonFetchRequests(networkRequests).length).toBe(2);
+
+    });
+
+    // Try to reduce indeterminism of browser requests by only returning fetch requests.
+    // Filter out preflight CORS, fetching stylesheets, page icons, etc. that can occur during tests
+    function filterNonFetchRequests(requests) {
+        return requests.filter(request => {
+            return (request.resourceType() === 'fetch');
+        });
+    }
+});
+
+/**
+ * @param {import('@playwright/test').Page} page
+ * @param {string} name
+ */
+async function expandTreePaneItemByName(page, name) {
+    const treePane = page.locator('#tree-pane');
+    const treeItem = treePane.locator(`role=treeitem[expanded=false][name=/${name}/]`);
+    const expandTriangle = treeItem.locator('.c-disclosure-triangle');
+    await expandTriangle.click();
+}

--- a/tests/e2e/yamcs/network.e2e.spec.js
+++ b/tests/e2e/yamcs/network.e2e.spec.js
@@ -41,16 +41,15 @@ test.describe("Quickstart network requests @yamcs", () => {
         networkRequests = [];
         await page.locator('text=CCSDS_Packet_Sequence').click();
         await page.waitForLoadState('networkidle');
-        // Network requests should be zero in real-time mode (using websocket cache)
-        expect(filterNonFetchRequests(networkRequests).length).toBe(0);
+        // Should fetch from parameter archive, so two requests, one for each item in the aggregate
+        expect(filterNonFetchRequests(networkRequests).length).toBe(2);
 
         networkRequests = [];
         await page.locator('text=CCSDS_Packet_Length').click();
         await page.waitForLoadState('networkidle');
-        // Network requests are:
-        // 1. Limit request from parameter archive
-        // 2. Telemetry from parameter archive
-        expect(filterNonFetchRequests(networkRequests).length).toBe(2);
+        // Should only be fetching telemetry from parameter archive,
+        // no second request (for limits) should be made
+        expect(filterNonFetchRequests(networkRequests).length).toBe(1);
 
         // Change to fixed time
         await page.locator('button:has-text("Local Clock")').click();
@@ -59,16 +58,15 @@ test.describe("Quickstart network requests @yamcs", () => {
         networkRequests = [];
         await page.locator('text=CCSDS_Packet_Sequence').click();
         await page.waitForLoadState('networkidle');
-        // Should now fetch from parameter archive, so two requests, one for each item in the aggregate
-        console.debug('🥕', filterNonFetchRequests(networkRequests));
+        // Should fetch from parameter archive, so two requests, one for each item in the aggregate
         expect(filterNonFetchRequests(networkRequests).length).toBe(2);
 
+        networkRequests = [];
         await page.locator('text=CCSDS_Packet_Length').click();
         await page.waitForLoadState('networkidle');
-        // Network requests should remain the same in fixed time:
-        // 1. Limit request from parameter archive
-        // 2. Telemetry from parameter archive
-        expect(filterNonFetchRequests(networkRequests).length).toBe(2);
+        // Should only be fetching telemetry from parameter archive,
+        // no second request (for limits) should be made
+        expect(filterNonFetchRequests(networkRequests).length).toBe(1);
 
     });
 


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #190 

### Describe your changes:
When we're loading the telemetry dictionary, we cache the limits for the telemetry object, and then use these cached limits later in the limit provider. This allows us to skip looking into the parameter archive for limit information.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
