### PR TITLE
6098 operator status indicator v11 improvements 1

### DIFF
--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -184,7 +184,6 @@ export default class YamcsObjectProvider {
     }
 
     async #loadTelemetryDictionary() {
-        console.debug(`🍇 Loading telemetry dictionary`);
         const operation = 'parameters?details=yes&limit=1000';
         const parameterUrl = this.url + 'api/mdb/' + this.instance + '/' + operation;
         const url = this.#getMdbUrl('space-systems');

--- a/src/providers/user/operator-status-telemetry.js
+++ b/src/providers/user/operator-status-telemetry.js
@@ -111,7 +111,8 @@ export default class OperatorStatusTelemetry {
 
         return {
             key: formatter.parse(datum),
-            label: formatter.format(datum)
+            label: formatter.format(datum),
+            timestamp: telemetryObject.timestamp
         };
 
     }

--- a/src/providers/user/operator-status-telemetry.js
+++ b/src/providers/user/operator-status-telemetry.js
@@ -108,11 +108,13 @@ export default class OperatorStatusTelemetry {
         const metadata = this.#openmct.telemetry.getMetadata(telemetryObject);
         const rangeMetadata = metadata.valuesForHints(['range'])[0];
         const formatter = this.#openmct.telemetry.getValueFormatter(rangeMetadata);
+        const timestampMetadata = metadata.valuesForHints(['domain'])[0];
+        const dateFormatter = this.#openmct.telemetry.getValueFormatter(timestampMetadata);
 
         return {
             key: formatter.parse(datum),
             label: formatter.format(datum),
-            timestamp: telemetryObject.timestamp
+            timestamp: dateFormatter.parse(datum)
         };
 
     }


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6098

### Describe your changes:
Adds date to operator status responses to poll questions so we can calculate an age.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
