### PR TITLE
Have latest telemetry always be delivered to consumers

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -50,7 +50,8 @@ export default function installYamcsPlugin(configuration) {
         const historicalTelemetryProvider = new YamcsHistoricalTelemetryProvider(
             openmct,
             configuration.yamcsHistoricalEndpoint,
-            configuration.yamcsInstance);
+            configuration.yamcsInstance,
+            latestTelemetryProvider);
         openmct.telemetry.addProvider(historicalTelemetryProvider);
 
         const realtimeTelemetryProvider = new RealtimeProvider(

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -60,7 +60,6 @@ export default class YamcsHistoricalTelemetryProvider {
         if ((options.strategy === 'latest') && options.timeContext?.isRealTime()) {
             // Latest requested in realtime, use latest telemetry provider instead
             const mctDatum = await this.latestTelemetryProvider.requestLatest(domainObject);
-            console.debug(`🤠 Latest telemetry provider returned for ${mctDatum.id}`, mctDatum);
 
             return [mctDatum];
         }

--- a/src/providers/latest-telemetry-provider.js
+++ b/src/providers/latest-telemetry-provider.js
@@ -26,6 +26,8 @@ import {
     qualifiedNameToId
 } from '../utils.js';
 
+const BATCH_DEBOUNCE_MS = 100;
+
 export default class LatestTelemetryProvider {
     #bulkPromise;
     #batchIds;
@@ -76,7 +78,7 @@ export default class LatestTelemetryProvider {
         // We until the next event loop cycle to "collect" all of the get
         // requests triggered in this iteration of the event loop
 
-        await this.#waitOneEventCycle();
+        await this.#waitForDebounce();
         let batchIds = [...new Set(this.#batchIds)];
 
         this.#clearBatch();
@@ -120,9 +122,14 @@ export default class LatestTelemetryProvider {
         this.#bulkPromise = undefined;
     }
 
-    #waitOneEventCycle() {
+    #waitForDebounce() {
+        let timeoutID;
+        clearTimeout(timeoutID);
+
         return new Promise((resolve) => {
-            setTimeout(resolve);
+            timeoutID = setTimeout(() => {
+                resolve();
+            }, BATCH_DEBOUNCE_MS);
         });
     }
 

--- a/src/providers/latest-telemetry-provider.js
+++ b/src/providers/latest-telemetry-provider.js
@@ -85,6 +85,7 @@ export default class LatestTelemetryProvider {
 
     }
     async #bulkGet(batchIds) {
+        console.debug(`👹 Fetching latest telemetry for ${batchIds.length} parameters`);
         const yamcsIds = batchIds.map((yamcsId) => {
             return {
                 name: yamcsId

--- a/src/providers/latest-telemetry-provider.js
+++ b/src/providers/latest-telemetry-provider.js
@@ -87,7 +87,6 @@ export default class LatestTelemetryProvider {
 
     }
     async #bulkGet(batchIds) {
-        console.debug(`👹 Fetching latest telemetry for ${batchIds.length} parameters`);
         const yamcsIds = batchIds.map((yamcsId) => {
             return {
                 name: yamcsId

--- a/tests/e2e/yamcs/network.e2e.spec.js
+++ b/tests/e2e/yamcs/network.e2e.spec.js
@@ -26,7 +26,7 @@ Network Specific Tests
 
 const { test, expect } = require('../opensource/pluginFixtures');
 
-test.describe.only("Quickstart network requests @yamcs", () => {
+test.describe("Quickstart network requests @yamcs", () => {
     // Collect all request events, specifically for YAMCS
     let networkRequests = [];
     let filteredRequests = [];
@@ -47,11 +47,10 @@ test.describe.only("Quickstart network requests @yamcs", () => {
         // wait for debounced requests in YAMCS Latest Telemetry Provider to finish
         await new Promise(resolve => setTimeout(resolve, 500));
 
-        // Network requests for the composite telemetry with 4 items should be 1
-        // due to batched requests for latest telemetry using the bulk API
         filteredRequests = filterNonFetchRequests(networkRequests);
-        //console.debug('🐥 filteredRequests:');
-        //console.debug(filteredRequests);
+
+        // Network requests for the composite telemetry with multiple items should be:
+        // 1.  batched request for latest telemetry using the bulk API
         expect(filteredRequests.length).toBe(1);
 
         await page.waitForLoadState('networkidle');
@@ -62,10 +61,11 @@ test.describe.only("Quickstart network requests @yamcs", () => {
         // wait for debounced requests in YAMCS Latest Telemetry Provider to finish
         await new Promise(resolve => setTimeout(resolve, 500));
 
-        // Should only be fetching telemetry from parameter archive
         filteredRequests = filterNonFetchRequests(networkRequests);
-        //console.debug('🐥 filteredRequests:');
-        //console.debug(filteredRequests);
+
+        // Should only be fetching:
+        // 1. telemetry from parameter archive
+        // 2. batched request for latest telemetry using the bulk API
         expect(filteredRequests.length).toBe(2);
 
         // Change to fixed time
@@ -80,10 +80,12 @@ test.describe.only("Quickstart network requests @yamcs", () => {
         // wait for debounced requests in YAMCS Latest Telemetry Provider to finish
         await new Promise(resolve => setTimeout(resolve, 500));
 
-        // Should fetch from parameter archive, so two requests, one for each item in the aggregate
         filteredRequests = filterNonFetchRequests(networkRequests);
-        //console.debug('🐥 filteredRequests:');
-        //console.debug(filteredRequests);
+
+        // Should fetch from parameter archive, so:
+        // 1. GET for first telemetry item from parameter archive
+        // 2. GET for second telemetry item from parameter archive
+        // 3. batched request for latest telemetry using the bulk API
         expect(filteredRequests.length).toBe(3);
 
         await page.waitForLoadState('networkidle');
@@ -93,12 +95,12 @@ test.describe.only("Quickstart network requests @yamcs", () => {
 
         // wait for debounced requests in YAMCS Latest Telemetry Provider to finish
         await new Promise(resolve => setTimeout(resolve, 500));
+        filteredRequests = filterNonFetchRequests(networkRequests);
 
         // Should only be fetching telemetry from parameter archive,
-        // no second request (for limits) should be made
-        filteredRequests = filterNonFetchRequests(networkRequests);
-        //console.debug('🐥 filteredRequests:');
-        //console.debug(filteredRequests);
+        // with no further request for limits should be made. So:
+        // 1. GET for telemetry item from parameter archive
+        // 2. batched request for latest telemetry using the bulk API
         expect(filteredRequests.length).toBe(2);
 
         networkRequests = [];
@@ -113,9 +115,8 @@ test.describe.only("Quickstart network requests @yamcs", () => {
         // 2. space systems
         // 3. parameter dictionary
         // 4. specific parameter telemetry for CCSDS_Packet_Length
+        // 5. batched request for latest telemetry using the bulk API
         filteredRequests = filterNonFetchRequests(networkRequests);
-        //console.debug('🐥 filteredRequests:');
-        //console.debug(filteredRequests);
         expect(filteredRequests.length).toBe(5);
 
     });


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #271 

### Describe your changes:
If asking for latest in historical telemetry provider, defer to the latest telemetry provider for batched retrieval.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
