### PR TITLE
Add telemetry metadata to parameters of type array

### DIFF
--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -406,6 +406,10 @@ export default class YamcsObjectProvider {
                 });
             }
 
+            if (this.#isArray(parameter)) {
+                telemetryValue.format = parameter.type.engType;
+            }
+
             obj.telemetry.values.push(telemetryValue);
 
             this.#addHints(key, obj);
@@ -451,6 +455,10 @@ export default class YamcsObjectProvider {
         return parameter?.type?.engType === 'enumeration';
     }
 
+    #isArray(parameter) {
+        return parameter?.type?.engType.endsWith('[]');
+    }
+
     #formatAggregateMembers(members, parentKey = '', rangeHint = 1) {
         let formatted = [];
 
@@ -467,13 +475,24 @@ export default class YamcsObjectProvider {
             }
 
             if (!this.#isAggregate(member)) {
-                formatted.push({
-                    key,
-                    name,
-                    hints: {
-                        range: rangeHint++
-                    }
-                });
+                if (this.#isArray(member)) {
+                    formatted.push({
+                        key,
+                        name,
+                        hints: {
+                            range: rangeHint++
+                        },
+                        format: member.type.engType
+                    });
+                } else {
+                    formatted.push({
+                        key,
+                        name,
+                        hints: {
+                            range: rangeHint++
+                        }
+                    });
+                }
             } else if (this.#aggregateHasMembers(member)) {
                 let formattedSubMembers = this.#formatAggregateMembers(member.type.member, key, rangeHint);
                 formatted = formatted.concat(formattedSubMembers);

--- a/src/utils.js
+++ b/src/utils.js
@@ -107,7 +107,7 @@ function getValue(item, name) {
             valueResults.push(VALUE_EXTRACT_MAP[arrayValue.type](arrayValue));
         }
 
-        return JSON.stringify(valueResults);
+        return valueResults;
     }
 
     if (value.type === AGGREGATE_TYPE) {


### PR DESCRIPTION
Closes #292 

### Describe your changes:
Add `format` metadata for Array parameters
Ensure that array values are not represented as strings so that the values can be displayed  correctly in Open MCT

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
