### PR TITLE
fix: increment expected requests due to staleness

### DIFF
--- a/tests/e2e/yamcs/network.e2e.spec.js
+++ b/tests/e2e/yamcs/network.e2e.spec.js
@@ -69,7 +69,8 @@ test.describe("Quickstart network requests @yamcs", () => {
 
         // Should only be fetching:
         // 1. telemetry from parameter archive
-        expect(filteredRequests.length).toBe(1);
+        // 2. POST: batchGet for staleness
+        expect(filteredRequests.length).toBe(2);
 
         // Change to fixed time
         await page.locator('button:has-text("Local Clock")').click();
@@ -88,7 +89,8 @@ test.describe("Quickstart network requests @yamcs", () => {
         // Should fetch from parameter archive, so:
         // 1. GET for first telemetry item from parameter archive
         // 2. GET for second telemetry item from parameter archive
-        expect(filteredRequests.length).toBe(2);
+        // 3. POST: batchGet for staleness
+        expect(filteredRequests.length).toBe(3);
 
         await page.waitForLoadState('networkidle');
         networkRequests = [];
@@ -102,7 +104,8 @@ test.describe("Quickstart network requests @yamcs", () => {
         // Should only be fetching telemetry from parameter archive,
         // with no further request for limits should be made.
         // 1. GET for telemetry item from parameter archive
-        expect(filteredRequests.length).toBe(1);
+        // 2. POST: batchGet for staleness
+        expect(filteredRequests.length).toBe(2);
 
         networkRequests = [];
         await page.reload();
@@ -116,8 +119,9 @@ test.describe("Quickstart network requests @yamcs", () => {
         // 2. space systems
         // 3. parameter dictionary
         // 4. specific parameter telemetry for CCSDS_Packet_Length
+        // 5. POST: batchGet for staleness
         filteredRequests = filterNonFetchRequests(networkRequests);
-        expect(filteredRequests.length).toBe(4);
+        expect(filteredRequests.length).toBe(5);
 
     });
 


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #307 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Increments expected network requests in the quickstart network test due to a new POST for a batchGet of staleness for the navigated telemetry.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
