### PR TITLE
Support filtering by severity for events tables

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -55,6 +55,7 @@ const openmct = window.openmct;
         openmct.install(openmct.plugins.LocalStorage());
         openmct.install(openmct.plugins.Espresso());
         openmct.install(openmct.plugins.MyItems());
+        openmct.install(openmct.plugins.Filters(['telemetry.plot.overlay', 'table']));
         openmct.install(openmct.plugins.example.Generator());
         openmct.install(openmct.plugins.example.ExampleImagery());
         openmct.install(openmct.plugins.UTCTimeSystem());

--- a/src/const.js
+++ b/src/const.js
@@ -48,6 +48,8 @@ export const STALENESS_STATUS_MAP = {
     'EXPIRED': true
 };
 
+export const SEVERITY_LEVELS = ['info', 'watch', 'warning', 'distress', 'critical', 'severe'];
+
 export const METADATA_TIME_KEY = 'generationTime';
 
 export const UNSUPPORTED_TYPE = 'Unsupported Data Type';

--- a/src/providers/events.js
+++ b/src/providers/events.js
@@ -40,28 +40,29 @@ export function createEventsObject(openmct, parentKey, namespace) {
             values: [
                 {
                     key: 'severity',
-                    name: 'Severity',
+                    name: 'Minimum Severity Threshold',
                     filters: [{
+                        singleSelectionThreshold: true,
                         comparator: 'equals',
                         possibleValues: [
                             {
-                                value: true,
-                                label: 'info'
+                                value: 'info',
+                                label: 'Info'
                             }, {
-                                value: false,
-                                label: 'watch'
+                                value: 'watch',
+                                label: 'Watch'
                             }, {
-                                value: false,
-                                label: 'warning'
+                                value: 'warning',
+                                label: 'Warning'
                             }, {
-                                value: false,
-                                label: 'distress'
+                                value: 'distress',
+                                label: 'Distress'
                             }, {
-                                value: false,
-                                label: 'critical'
+                                value: 'critical',
+                                label: 'Critical'
                             }, {
-                                value: false,
-                                label: 'severe'
+                                value: 'severe',
+                                label: 'Severe'
                             }
                         ]
                     }]

--- a/src/providers/events.js
+++ b/src/providers/events.js
@@ -40,7 +40,31 @@ export function createEventsObject(openmct, parentKey, namespace) {
             values: [
                 {
                     key: 'severity',
-                    name: 'Severity'
+                    name: 'Severity',
+                    filters: [{
+                        comparator: 'equals',
+                        possibleValues: [
+                            {
+                                value: true,
+                                label: 'info'
+                            }, {
+                                value: false,
+                                label: 'watch'
+                            }, {
+                                value: false,
+                                label: 'warning'
+                            }, {
+                                value: false,
+                                label: 'distress'
+                            }, {
+                                value: false,
+                                label: 'critical'
+                            }, {
+                                value: false,
+                                label: 'severe'
+                            }
+                        ]
+                    }]
                 },
                 {
                     key: 'utc',

--- a/src/providers/events.js
+++ b/src/providers/events.js
@@ -19,7 +19,7 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-import { OBJECT_TYPES, METADATA_TIME_KEY } from "../const";
+import { OBJECT_TYPES, METADATA_TIME_KEY, SEVERITY_LEVELS } from "../const";
 
 export function createEventsObject(openmct, parentKey, namespace) {
     const location = openmct.objects.makeKeyString({
@@ -40,31 +40,16 @@ export function createEventsObject(openmct, parentKey, namespace) {
             values: [
                 {
                     key: 'severity',
-                    name: 'Minimum Severity Threshold',
+                    name: 'Severity Threshold',
                     filters: [{
                         singleSelectionThreshold: true,
                         comparator: 'equals',
-                        possibleValues: [
-                            {
-                                value: 'info',
-                                label: 'Info'
-                            }, {
-                                value: 'watch',
-                                label: 'Watch'
-                            }, {
-                                value: 'warning',
-                                label: 'Warning'
-                            }, {
-                                value: 'distress',
-                                label: 'Distress'
-                            }, {
-                                value: 'critical',
-                                label: 'Critical'
-                            }, {
-                                value: 'severe',
-                                label: 'Severe'
-                            }
-                        ]
+                        possibleValues: SEVERITY_LEVELS.map((level) => {
+                            return {
+                                label: level,
+                                value: level
+                            };
+                        })
                     }]
                 },
                 {
@@ -105,6 +90,18 @@ export function createEventsObject(openmct, parentKey, namespace) {
     };
 
     return eventsObject;
+}
+
+export function eventShouldBeFiltered(event, options) {
+    const { severity } = event;
+    const incomingEventSeverity = severity?.toLowerCase();
+    const severityLevelToFilter = options?.filters?.severity?.equals?.[0];
+    const severityLevelToFilterIndex = SEVERITY_LEVELS.indexOf(severityLevelToFilter);
+    const incomingEventSeverityIndex = SEVERITY_LEVELS.indexOf(incomingEventSeverity);
+    console.debug(`🔮 incoming event has severity ${incomingEventSeverity} with index ${incomingEventSeverityIndex}`);
+    console.debug(`🔮 filter severity is ${severityLevelToFilter} with index ${severityLevelToFilterIndex}`);
+
+    return incomingEventSeverityIndex < severityLevelToFilterIndex;
 }
 
 /**

--- a/src/providers/events.js
+++ b/src/providers/events.js
@@ -98,8 +98,6 @@ export function eventShouldBeFiltered(event, options) {
     const severityLevelToFilter = options?.filters?.severity?.equals?.[0];
     const severityLevelToFilterIndex = SEVERITY_LEVELS.indexOf(severityLevelToFilter);
     const incomingEventSeverityIndex = SEVERITY_LEVELS.indexOf(incomingEventSeverity);
-    console.debug(`🔮 incoming event has severity ${incomingEventSeverity} with index ${incomingEventSeverityIndex}`);
-    console.debug(`🔮 filter severity is ${severityLevelToFilter} with index ${severityLevelToFilterIndex}`);
 
     return incomingEventSeverityIndex < severityLevelToFilterIndex;
 }

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -66,7 +66,7 @@ export default class YamcsObjectProvider {
         this.#dictionary = {};
         this.#spaceSystemPromise = null;
         this.#parameterLoadingQueue = [];
-        this.flushparameterLoadingQueue = _.debounce(this.flushparameterLoadingQueue.bind(this));
+        this.flushparameterLoadingQueue = _.debounce(this.flushparameterLoadingQueue.bind(this), BATCH_DEBOUNCE_MS);
         this.#roleStatusTelemetry = roleStatusTelemetry;
         this.#pollQuestionParameter = pollQuestionParameter;
         this.#pollQuestionTelemetry = pollQuestionTelemetry;

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -22,6 +22,7 @@
 
 import {
     qualifiedNameToId,
+    idToQualifiedName,
     accumulateResults
 } from '../utils.js';
 
@@ -30,34 +31,53 @@ import OperatorStatusParameter from './user/operator-status-parameter.js';
 import { createCommandsObject } from './commands.js';
 import { createEventsObject } from './events.js';
 import limitConfig from "../limits-config.json";
+import _ from 'lodash';
 
 const YAMCS_API_MAP = {
     'space-systems': 'spaceSystems',
     'parameters': 'parameters'
 };
 const operatorStatusParameter = new OperatorStatusParameter();
+const BATCH_DEBOUNCE_MS = 100;
 
 export default class YamcsObjectProvider {
+    #openmct;
+    #url;
+    #instance;
+    #bulkParameterUrl;
+    #folderName;
+    #namespace;
+    #key;
+    #dictionary;
+    #spaceSystemPromise;
+    #parameterLoadingQueue;
+    #roleStatusTelemetry;
+    #pollQuestionParameter;
+    #pollQuestionTelemetry;
+
     constructor(openmct, url, instance, folderName, roleStatusTelemetry, pollQuestionParameter, pollQuestionTelemetry) {
-        this.openmct = openmct;
-        this.url = url;
-        this.instance = instance;
-        this.folderName = folderName;
-        this.namespace = NAMESPACE;
-        this.key = 'spacecraft';
-        this.dictionary = {};
-        this.dictionaryPromise = null;
-        this.roleStatusTelemetry = roleStatusTelemetry;
-        this.pollQuestionParameter = pollQuestionParameter;
-        this.pollQuestionTelemetry = pollQuestionTelemetry;
+        this.#openmct = openmct;
+        this.#url = url;
+        this.#instance = instance;
+        this.#bulkParameterUrl = new URL(`${this.#url}api/mdb/${this.#instance}/parameters:batchGet`);
+        this.#folderName = folderName;
+        this.#namespace = NAMESPACE;
+        this.#key = 'spacecraft';
+        this.#dictionary = {};
+        this.#spaceSystemPromise = null;
+        this.#parameterLoadingQueue = [];
+        this.flushparameterLoadingQueue = _.debounce(this.flushparameterLoadingQueue.bind(this));
+        this.#roleStatusTelemetry = roleStatusTelemetry;
+        this.#pollQuestionParameter = pollQuestionParameter;
+        this.#pollQuestionTelemetry = pollQuestionTelemetry;
 
         this.#initialize();
     }
 
     #initialize() {
         this.#createRootObject();
-        const eventsObject = createEventsObject(this.openmct, this.key, this.namespace);
-        const commandsObject = createCommandsObject(this.openmct, this.key, this.namespace);
+        const eventsObject = createEventsObject(this.#openmct, this.#key, this.#namespace);
+        const commandsObject = createCommandsObject(this.#openmct, this.#key, this.#namespace);
         this.#addObject(commandsObject);
         this.#addObject(eventsObject);
         this.rootObject.composition.push(
@@ -69,10 +89,10 @@ export default class YamcsObjectProvider {
     #createRootObject() {
         this.rootObject = {
             identifier: {
-                key: this.key,
-                namespace: this.namespace
+                key: this.#key,
+                namespace: this.#namespace
             },
-            name: this.folderName,
+            name: this.#folderName,
             type: 'folder',
             location: 'ROOT',
             composition: []
@@ -84,12 +104,78 @@ export default class YamcsObjectProvider {
     async get(identifier) {
         const { key } = identifier;
         const dictionary = await this.#getTelemetryDictionary();
+        if (dictionary[key]) {
+            return dictionary[key];
+        } else {
+            // need to lazy load this
+            console.debug(`❓ Lazy loading ${key} from dictionary`);
 
-        return dictionary[key];
+            return new Promise((resolve, reject) => {
+                this.#parameterLoadingQueue.push({
+                    key,
+                    resolve,
+                    reject
+                });
+                this.flushparameterLoadingQueue();
+            });
+        }
+    }
+
+    async flushparameterLoadingQueue(abortSignal) {
+        if (this.#parameterLoadingQueue.length >= 1) {
+            const batch = this.#parameterLoadingQueue.map((queued) => {
+                const parameterName = idToQualifiedName(queued.key);
+                console.debug(`📦 Adding ${parameterName} to batch request`);
+
+                return {
+                    name: parameterName,
+                };
+            });
+            const bodyForYamcs = {
+                id: batch
+            };
+            const fetchOptions = {
+                method: 'POST',
+                body: JSON.stringify(bodyForYamcs),
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                signal: abortSignal
+            };
+            console.debug(`📦 Fetching ${batch.length} objects from dictionary`, bodyForYamcs);
+            const bulkGetResponse = await fetch(this.#bulkParameterUrl, fetchOptions);
+            if (!bulkGetResponse.ok) {
+                const error = new Error(`Failed to fetch objects from dictionary: ${bulkGetResponse.statusText}`);
+                error.response = bulkGetResponse;
+                this.#parameterLoadingQueue.forEach((queuedObject) => {
+                    queuedObject.reject(error);
+                });
+
+                return;
+            }
+
+            const parameterResults = await bulkGetResponse.json();
+            parameterResults.response.forEach((parameterResult) => {
+                const foundQueuedParameter = this.#parameterLoadingQueue.find((queuedParameter) => {
+                    const transformedResultName = qualifiedNameToId(parameterResult.parameter.qualifiedName);
+
+                    return queuedParameter.key === transformedResultName;
+                });
+                if (foundQueuedParameter) {
+                    console.debug(`📦 Building parameter`, parameterResult.parameter);
+                    this.#addParameterObject(parameterResult.parameter);
+                    const builtParameter = this.#dictionary[foundQueuedParameter.key];
+                    foundQueuedParameter.resolve(builtParameter);
+                }
+            });
+            console.debug(`📦 Received ${parameterResults.response.length} objects from dictionary`);
+        }
+
+        this.persistenceQueue = [];
     }
 
     supportsSearchType(type) {
-        return type === this.openmct.objects.SEARCH_TYPES.OBJECTS;
+        return type === this.#openmct.objects.SEARCH_TYPES.OBJECTS;
     }
 
     async search(query, abortSignal, searchType) {
@@ -104,7 +190,7 @@ export default class YamcsObjectProvider {
     async #convertSingleSearchHitToTelemetry(qualifiedName) {
         const identifier = {
             key: qualifiedNameToId(qualifiedName),
-            namespace: this.namespace
+            namespace: this.#namespace
         };
         const telemetry = await this.get(identifier);
 
@@ -136,6 +222,7 @@ export default class YamcsObjectProvider {
     }
 
     async #searchMdbApi(operation, query, abortSignal) {
+        console.debug(`🕵️‍♀️ Searching MDB API for ${operation} with query ${query}`);
         const key = YAMCS_API_MAP[operation];
         const search = await this.#fetchMdbApi(`${operation}?q=${query}&searchMembers=true&details=false`, abortSignal);
         const hits = search[key];
@@ -173,22 +260,19 @@ export default class YamcsObjectProvider {
     }
 
     #getTelemetryDictionary() {
-        if (!this.dictionaryPromise) {
-            this.dictionaryPromise = this.#loadTelemetryDictionary(this.url, this.instance, this.folderName)
+        if (!this.#spaceSystemPromise) {
+            this.#spaceSystemPromise = this.#loadSpaceSystems(this.#url, this.#instance, this.#folderName)
                 .finally(() => {
-                    this.roleStatusTelemetry.dictionaryLoadComplete();
+                    this.#roleStatusTelemetry.dictionaryLoadComplete();
                 });
         }
 
-        return this.dictionaryPromise;
+        return this.#spaceSystemPromise;
     }
 
-    async #loadTelemetryDictionary() {
-        const operation = 'parameters?details=yes&limit=1000';
-        const parameterUrl = this.url + 'api/mdb/' + this.instance + '/' + operation;
+    async #loadSpaceSystems() {
         const url = this.#getMdbUrl('space-systems');
         const spaceSystems = await accumulateResults(url, {}, 'spaceSystems', []);
-        const parameters = await accumulateResults(parameterUrl, {}, 'parameters', []);
 
         /* Sort the space systems by name, so that the
             children of the root object are in sorted order. */
@@ -199,19 +283,15 @@ export default class YamcsObjectProvider {
             this.#addSpaceSystem(spaceSystem);
         });
 
-        parameters.forEach(parameter => {
-            this.#addParameterObject(parameter);
-        });
-
-        return this.dictionary;
+        return this.#dictionary;
     }
 
     #getMdbUrl(operation, name = '') {
-        return this.url + 'api/mdb/' + this.instance + '/' + operation + name;
+        return this.#url + 'api/mdb/' + this.#instance + '/' + operation + name;
     }
 
     async #fetchMdbApi(operation, abortSignal) {
-        const mdbURL = `${this.url}api/mdb/${this.instance}/${operation}`;
+        const mdbURL = `${this.#url}api/mdb/${this.#instance}/${operation}`;
         const response = await fetch(mdbURL, { signal: abortSignal });
         const parsedJSON = await response.json();
 
@@ -231,7 +311,7 @@ export default class YamcsObjectProvider {
                     let subId = qualifiedNameToId(sub.qualifiedName);
                     composition.push({
                         key: subId,
-                        namespace: this.namespace
+                        namespace: this.#namespace
                     });
                 });
             }
@@ -239,15 +319,15 @@ export default class YamcsObjectProvider {
             let id = qualifiedNameToId(spaceSystem.qualifiedName);
             const locationId = id.substring(0, id.lastIndexOf('~'));
             const isSubSystem = locationId.includes('~');
-            const key = isSubSystem ? locationId : this.key;
-            const location = this.openmct.objects.makeKeyString({
-                namespace: this.namespace,
+            const key = isSubSystem ? locationId : this.#key;
+            const location = this.#openmct.objects.makeKeyString({
+                namespace: this.#namespace,
                 key: key
             });
             let obj = {
                 identifier: {
                     key: id,
-                    namespace: this.namespace
+                    namespace: this.#namespace
                 },
                 name: spaceSystem.name,
                 type: 'folder',
@@ -261,14 +341,14 @@ export default class YamcsObjectProvider {
             if (spaceSystem.qualifiedName.lastIndexOf('/') === 0) {
                 this.rootObject.composition.push({
                     key: id,
-                    namespace: this.namespace
+                    namespace: this.#namespace
                 });
             }
         }
     }
 
     #addObject(object) {
-        this.dictionary[object.identifier.key] = object;
+        this.#dictionary[object.identifier.key] = object;
     }
 
     /*
@@ -280,7 +360,7 @@ export default class YamcsObjectProvider {
             let qn = parameter.qualifiedName;
             let lastSlashPos = qn.lastIndexOf('/');
             let parentId = qualifiedNameToId(qn.substring(0, lastSlashPos));
-            let parent = this.dictionary[parentId];
+            let parent = this.#dictionary[parentId];
 
             this.#addParameter(parameter, qn, parent, '');
         }
@@ -321,14 +401,14 @@ export default class YamcsObjectProvider {
     #addParameter(parameter, qualifiedName, parent, prefix) {
         const id = qualifiedNameToId(qualifiedName);
         const name = prefix + parameter.name;
-        const location = this.openmct.objects.makeKeyString({
+        const location = this.#openmct.objects.makeKeyString({
             key: parent.identifier.key,
             namespace: parent.identifier.namespace
         });
         const obj = {
             identifier: {
                 key: id,
-                namespace: this.namespace
+                namespace: this.#namespace
             },
             type: this.#getParameterType(parameter),
             name: name,
@@ -377,14 +457,14 @@ export default class YamcsObjectProvider {
                 }
 
                 const possibleStatuses = operatorStatusParameter.getPossibleStatusesFromParameter(parameter);
-                possibleStatuses.forEach(state => this.roleStatusTelemetry.addStatus(state));
-                this.roleStatusTelemetry.addStatusRole(role);
-                this.roleStatusTelemetry.setTelemetryObjectForRole(role, obj);
+                possibleStatuses.forEach(state => this.#roleStatusTelemetry.addStatus(state));
+                this.#roleStatusTelemetry.addStatusRole(role);
+                this.#roleStatusTelemetry.setTelemetryObjectForRole(role, obj);
             }
 
-            if (this.pollQuestionParameter.isPollQuestionParameter(parameter)) {
-                this.pollQuestionParameter.setPollQuestionParameter(parameter);
-                this.pollQuestionTelemetry.setTelemetryObject(obj);
+            if (this.#pollQuestionParameter.isPollQuestionParameter(parameter)) {
+                this.#pollQuestionParameter.setPollQuestionParameter(parameter);
+                this.#pollQuestionTelemetry.setTelemetryObject(obj);
                 telemetryValue.format = 'string';
             }
 

--- a/src/providers/realtime-provider.js
+++ b/src/providers/realtime-provider.js
@@ -30,7 +30,7 @@ import {
     addLimitInformation
 } from '../utils.js';
 import { commandToTelemetryDatum } from './commands';
-import { eventToTelemetryDatum } from './events';
+import { eventToTelemetryDatum, eventShouldBeFiltered } from './events';
 
 const FALLBACK_AND_WAIT_MS = [1000, 5000, 5000, 10000, 10000, 30000];
 export default class RealtimeProvider {
@@ -83,8 +83,8 @@ export default class RealtimeProvider {
         return this.supportedDataTypes[type];
     }
 
-    subscribe(domainObject, callback) {
-        let subscriptionDetails = this.buildSubscriptionDetails(domainObject, callback);
+    subscribe(domainObject, callback, options) {
+        let subscriptionDetails = this.buildSubscriptionDetails(domainObject, callback, options);
         let id = subscriptionDetails.subscriptionId;
         this.subscriptionsById[id] = subscriptionDetails;
 
@@ -102,7 +102,7 @@ export default class RealtimeProvider {
         };
     }
 
-    buildSubscriptionDetails(domainObject, callback) {
+    buildSubscriptionDetails(domainObject, callback, options) {
         let subscriptionId = this.lastSubscriptionId++;
         let subscriptionDetails = {
             instance: this.instance,
@@ -110,6 +110,7 @@ export default class RealtimeProvider {
             name: idToQualifiedName(domainObject.identifier.key),
             domainObject,
             updateOnExpiration: true,
+            options,
             callback: callback
         };
 
@@ -175,7 +176,7 @@ export default class RealtimeProvider {
             clearTimeout(this.reconnectTimeout);
 
             this.connected = true;
-            console.log(`🔌 Established websocket connection to ${wsUrl}`);
+            console.debug(`🔌 Established websocket connection to ${wsUrl}`);
 
             this.currentWaitIndex = 0;
             this.resubscribeToAll();
@@ -246,8 +247,12 @@ export default class RealtimeProvider {
                     const datum = commandToTelemetryDatum(message.data);
                     subscriptionDetails.callback(datum);
                 } else if (this.isEventMessage(message)) {
-                    const datum = eventToTelemetryDatum(message.data);
-                    subscriptionDetails.callback(datum);
+                    if (eventShouldBeFiltered(message.data, subscriptionDetails.options)) {
+                        // ignore event
+                    } else {
+                        const datum = eventToTelemetryDatum(message.data);
+                        subscriptionDetails.callback(datum);
+                    }
                 } else {
                     subscriptionDetails.callback(message.data);
                 }

--- a/src/providers/user/operator-status-telemetry.js
+++ b/src/providers/user/operator-status-telemetry.js
@@ -119,6 +119,7 @@ export default class OperatorStatusTelemetry {
 
     }
     dictionaryLoadComplete() {
+        // TODO: this will never be called with the new lazy loaded dictionary
         this.#setReady();
     }
     #buildUrl(id) {

--- a/tests/e2e/yamcs/filters.e2e.spec.js
+++ b/tests/e2e/yamcs/filters.e2e.spec.js
@@ -25,7 +25,7 @@ Filter Specific Tests
 */
 
 const { test, expect } = require('../opensource/pluginFixtures');
-const { createDomainObjectWithDefaults } = require('../opensource/appActions');
+const { createDomainObjectWithDefaults, selectInspectorTab } = require('../opensource/appActions');
 
 test.describe("Filter tests @yamcs", () => {
     test('Can filter events by severity', async ({ page }) => {
@@ -41,28 +41,28 @@ test.describe("Filter tests @yamcs", () => {
         await eventsTreeItem.dragTo(objectPane);
 
         // ensure global filters work
-        await page.getByText('Filters', { exact: true }).click({ force: true });
+        await selectInspectorTab(page, 'Filters');
         await page.getByRole('listitem').filter({ hasText: 'Global Filtering' }).locator('span').click();
         await page.getByRole('listitem').filter({ hasText: 'Events' }).locator('span').click();
-        await page.getByRole('combobox').nth(0).selectOption('critical');
+        await page.locator('[aria-label="Global Filter"]').selectOption('critical');
         await expect(page.getByText('Filters applied')).toBeVisible();
         await expect(page.getByTitle('Data filters are being applied to this view.').getByText('critical')).toBeVisible();
-        await page.getByRole('combobox').nth(0).selectOption('NONE');
+        await page.locator('[aria-label="Global Filter"]').selectOption('NONE');
         await expect(page.getByText('Filters applied')).toBeHidden();
         await expect(page.getByTitle('Data filters are being applied to this view.')).toBeHidden();
 
         // ensure specific object filters work
         await page.getByRole('switch').click();
-        await page.getByRole('combobox').nth(1).selectOption('info');
+        await page.locator('[aria-label="Specific Filter"]').selectOption('info');
         await expect(page.getByText('Filters applied')).toBeVisible();
         await expect(page.getByTitle('Data filters are being applied to this view.').getByText('info')).toBeVisible();
-        await page.getByRole('combobox').nth(1).selectOption('NONE');
+        await page.locator('[aria-label="Specific Filter"]').selectOption('NONE');
         await expect(page.getByText('Filters applied')).toBeHidden();
         await expect(page.getByTitle('Data filters are being applied to this view.')).toBeHidden();
 
         // ensure specific object filters override global filters
-        await page.getByRole('combobox').nth(1).selectOption('info');
-        await page.getByRole('combobox').nth(0).selectOption('critical');
+        await page.locator('[aria-label="Specific Filter"]').selectOption('info');
+        await page.locator('[aria-label="Global Filter"]').selectOption('critical');
         await expect(page.getByText('Filters applied')).toBeVisible();
         await expect(page.getByTitle('Data filters are being applied to this view.').getByText('info')).toBeVisible();
 

--- a/tests/e2e/yamcs/filters.e2e.spec.js
+++ b/tests/e2e/yamcs/filters.e2e.spec.js
@@ -1,0 +1,74 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2022, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+/*
+Filter Specific Tests
+*/
+
+const { test, expect } = require('../opensource/pluginFixtures');
+const { createDomainObjectWithDefaults } = require('../opensource/appActions');
+
+test.describe("Filter tests @yamcs", () => {
+    test('Can filter events by severity', async ({ page }) => {
+        // Go to baseURL
+        await page.goto("./", { waitUntil: "networkidle" });
+        const myProjectTreeItem = page.locator('.c-tree__item').filter({ hasText: 'myproject'});
+        const firstMyProjectTriangle = myProjectTreeItem.first().locator('span.c-disclosure-triangle');
+        await firstMyProjectTriangle.click();
+        const eventsTreeItem = page.getByRole('treeitem', { name: /Events/ });
+        await createDomainObjectWithDefaults(page, { type: 'Telemetry Table' });
+
+        const objectPane = page.locator('.c-object-view');
+        await eventsTreeItem.dragTo(objectPane);
+
+        // ensure global filters work
+        await page.getByText('Filters', { exact: true }).click({ force: true });
+        await page.getByRole('listitem').filter({ hasText: 'Global Filtering' }).locator('span').click();
+        await page.getByRole('listitem').filter({ hasText: 'Events' }).locator('span').click();
+        await page.getByRole('combobox').nth(0).selectOption('critical');
+        await expect(page.getByText('Filters applied')).toBeVisible();
+        await expect(page.getByTitle('Data filters are being applied to this view.').getByText('critical')).toBeVisible();
+        await page.getByRole('combobox').nth(0).selectOption('NONE');
+        await expect(page.getByText('Filters applied')).toBeHidden();
+        await expect(page.getByTitle('Data filters are being applied to this view.')).toBeHidden();
+
+        // ensure specific object filters work
+        await page.getByRole('switch').click();
+        await page.getByRole('combobox').nth(1).selectOption('info');
+        await expect(page.getByText('Filters applied')).toBeVisible();
+        await expect(page.getByTitle('Data filters are being applied to this view.').getByText('info')).toBeVisible();
+        await page.getByRole('combobox').nth(1).selectOption('NONE');
+        await expect(page.getByText('Filters applied')).toBeHidden();
+        await expect(page.getByTitle('Data filters are being applied to this view.')).toBeHidden();
+
+        // ensure specific object filters override global filters
+        await page.getByRole('combobox').nth(1).selectOption('info');
+        await page.getByRole('combobox').nth(0).selectOption('critical');
+        await expect(page.getByText('Filters applied')).toBeVisible();
+        await expect(page.getByTitle('Data filters are being applied to this view.').getByText('info')).toBeVisible();
+
+        // ensure global filters override when switch is on
+        await page.getByRole('switch').click();
+        await expect(page.getByText('Filters applied')).toBeVisible();
+        await expect(page.getByTitle('Data filters are being applied to this view.').getByText('critical')).toBeVisible();
+    });
+});


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #314 

### Describe your changes:

- Added severity threshold filter to events.
- Pass `options` to subscription builder so we can filter events client side for websocket messages.
- Pass filter to YAMCS for historical requests.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
