### PR TITLE
fix: use `minTime` and `maxTime` when handling sample responses

### DIFF
--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -255,11 +255,11 @@ export default class YamcsHistoricalTelemetryProvider {
             return [];
         }
 
-        let values = [];
+        const values = [];
         results.forEach(result => {
             if (result.n > 0) {
-                let min_value = {
-                    timestamp: result.time,
+                const min_value = {
+                    timestamp: result.minTime,
                     value: result.min,
                     id: id
                 };
@@ -269,8 +269,8 @@ export default class YamcsHistoricalTelemetryProvider {
             }
 
             if (result.n > 1) {
-                let max_value = {
-                    timestamp: result.time,
+                const max_value = {
+                    timestamp: result.maxTime,
                     value: result.max,
                     id: id
                 };


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #318 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->

Use `minTime` and `maxTime` result values when handling sample history responses.

The result is that when zooming in on telemetry, we no longer get weird artifacts like this:
![image](https://github.com/akhenry/openmct-yamcs/assets/9259993/5ef8e76e-393e-475e-858e-f6a256e79808)

Instead, a smooth graph:
![image](https://github.com/akhenry/openmct-yamcs/assets/9259993/d7c16126-b1e9-455f-83dd-2a5e24b2e9ef)


Note that this change will not be backwards-compatible with any yamcs version < 5.7.7. However, since the minimum yamcs version we support is tied to the version that quickstart uses (currently 5.8.1), this should be fine.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
