### PR TITLE
chore: bump version to `2.2.5-SNAPSHOT`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct-yamcs",
-  "version": "2.2.4-SNAPSHOT",
+  "version": "2.2.5-SNAPSHOT",
   "description": "An adapter for connecting Open MCT with YAMCS",
   "main": "dist/openmct-yamcs.js",
   "scripts": {


### PR DESCRIPTION
Version bump, title says all