### PR TITLE
[CI] let all workflows run to completion, add retries to steps, and update pr trigger logic to match vanilla openmct

### DIFF
--- a/.github/workflows/yamcs-quickstart-e2e.yml
+++ b/.github/workflows/yamcs-quickstart-e2e.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Get Openmct opensource e2e tests
         uses: nick-fields/retry@v2
         with:
+          timeout_minutes: 10
           max_attempts: 3
           command: npm run test:getopensource
       - name: Check that yamcs is available

--- a/.github/workflows/yamcs-quickstart-e2e.yml
+++ b/.github/workflows/yamcs-quickstart-e2e.yml
@@ -54,7 +54,12 @@ jobs:
           elif [ "${{ matrix.openmct-version }}" = "stable" ]; then
             npm run build:example
           fi
-      - run: npm run test:getopensource
+      - name: Get Openmct opensource e2e tests
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          run: npm run test:getopensource
       - name: Check that yamcs is available
         run: |
           docker ps -a

--- a/.github/workflows/yamcs-quickstart-e2e.yml
+++ b/.github/workflows/yamcs-quickstart-e2e.yml
@@ -57,9 +57,8 @@ jobs:
       - name: Get Openmct opensource e2e tests
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 10
           max_attempts: 3
-          run: npm run test:getopensource
+          command: npm run test:getopensource
       - name: Check that yamcs is available
         run: |
           docker ps -a

--- a/.github/workflows/yamcs-quickstart-e2e.yml
+++ b/.github/workflows/yamcs-quickstart-e2e.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   yamcs-quickstart-e2e:
+    if: ${{ github.event.label.name == 'pr:e2e:quickstart' }} || ${{ github.event.action == 'opened' }}
     timeout-minutes: 10
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -100,3 +101,20 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: tests/html-test-results
+      - name: Remove pr:e2e:quickstart label (if present)
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'pr:e2e:quickstart') }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { owner, repo, number } = context.issue;
+            const labelToRemove = 'pr:e2e:quickstart';
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: number,
+                name: labelToRemove
+              });
+            } catch (error) {
+              core.warning(`Failed to remove 'pr:e2e:quickstart' label: ${error.message}`);
+            }

--- a/.github/workflows/yamcs-quickstart-e2e.yml
+++ b/.github/workflows/yamcs-quickstart-e2e.yml
@@ -15,6 +15,7 @@ jobs:
   yamcs-quickstart-e2e:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
         yamcs-version:

--- a/.github/workflows/yamcs-quickstart-e2e.yml
+++ b/.github/workflows/yamcs-quickstart-e2e.yml
@@ -55,7 +55,7 @@ jobs:
           elif [ "${{ matrix.openmct-version }}" = "stable" ]; then
             npm run build:example
           fi
-      - name: Get Openmct opensource e2e tests
+      - name: Get Open MCT e2e tests
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 10


### PR DESCRIPTION
Addresses: #328 

### Describe your changes:
Not all workflows are running to completion which is going to be a problem if we start blocking

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
