### PR TITLE
Image thumbnail support

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -132,7 +132,7 @@ export default function installYamcsPlugin(configuration) {
 
         const formatThumbnail = {
             format: function (url) {
-                return `${url}?w=100&h=100`;
+                return url.replace(/\/images\//,'/rescaled-images/').replace(/.png$/, '_thumb.png');
             }
         };
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -130,6 +130,17 @@ export default function installYamcsPlugin(configuration) {
             key: 'spacecraft'
         });
 
+        const formatThumbnail = {
+            format: function (url) {
+                return `${url}?w=100&h=100`;
+            }
+        };
+
+        openmct.telemetry.addFormat({
+            key: 'thumbnail',
+            ...formatThumbnail
+        });
+
         openmct.objects.addProvider('taxonomy', objectProvider);
 
         openmct.types.addType(OBJECT_TYPES.AGGREGATE_TELEMETRY_TYPE, {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -137,7 +137,7 @@ export default function installYamcsPlugin(configuration) {
         };
 
         openmct.telemetry.addFormat({
-            key: 'thumbnail',
+            key: 'yamcs-thumbnail',
             ...formatThumbnail
         });
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -132,7 +132,7 @@ export default function installYamcsPlugin(configuration) {
 
         const formatThumbnail = {
             format: function (url) {
-                return url.replace(/\/images\//,'/rescaled-images/').replace(/.png$/, '_thumb.png');
+                return url.replace(/\/images\//,'/rescaled-images/').replace(/.png$/, '_thumb.jpeg');
             }
         };
 

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -441,6 +441,8 @@ export default class YamcsObjectProvider {
         if (obj.type === OBJECT_TYPES.STRING_OBJECT_TYPE) {
             metadatum.hints = {};
         } else if (obj.type === OBJECT_TYPES.IMAGE_OBJECT_TYPE) {
+            console.log('adding hints for image', key, metadatum);
+
             metadatum.hints = { image: 1 };
             metadatum.format = 'image';
         }

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -346,6 +346,19 @@ export default class YamcsObjectProvider {
                 }]
             }
         };
+
+        if (this.#isImage(obj)) {
+            obj.telemetry.values.push({
+                name: 'Image Thumbnail',
+                key: 'thumbnail-url',
+                format: 'thumbnail',
+                hints: {
+                    thumbnail: 1
+                },
+                source: 'url'
+            });
+        }
+
         const isAggregate = this.#isAggregate(parameter);
         let aggregateHasMembers = false;
 
@@ -440,9 +453,7 @@ export default class YamcsObjectProvider {
 
         if (obj.type === OBJECT_TYPES.STRING_OBJECT_TYPE) {
             metadatum.hints = {};
-        } else if (obj.type === OBJECT_TYPES.IMAGE_OBJECT_TYPE) {
-            console.log('adding hints for image', key, metadatum);
-
+        } else if (this.#isImage(obj)) {
             metadatum.hints = { image: 1 };
             metadatum.format = 'image';
         }
@@ -451,6 +462,10 @@ export default class YamcsObjectProvider {
 
     #isAggregate(parameter) {
         return parameter?.type?.engType === 'aggregate';
+    }
+
+    #isImage(obj) {
+        return (obj.type === OBJECT_TYPES.IMAGE_OBJECT_TYPE);
     }
 
     #isEnumeration(parameter) {

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -355,7 +355,7 @@ export default class YamcsObjectProvider {
                 hints: {
                     thumbnail: 1
                 },
-                source: 'url'
+                source: 'value'
             });
         }
 

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -349,9 +349,9 @@ export default class YamcsObjectProvider {
 
         if (this.#isImage(obj)) {
             obj.telemetry.values.push({
-                name: 'Image Thumbnail',
-                key: 'thumbnail-url',
-                format: 'thumbnail',
+                name: 'VIPER Image Thumbnail',
+                key: 'yamcs-thumbnail-url',
+                format: 'yamcs-thumbnail',
                 hints: {
                     thumbnail: 1
                 },

--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -349,7 +349,7 @@ export default class YamcsObjectProvider {
 
         if (this.#isImage(obj)) {
             obj.telemetry.values.push({
-                name: 'VIPER Image Thumbnail',
+                name: 'Image Thumbnail',
                 key: 'yamcs-thumbnail-url',
                 format: 'yamcs-thumbnail',
                 hints: {


### PR DESCRIPTION
Resolves VIPEROMCT-350

Add thumbnail metadata for image type objects in the object provider
Add thumbnail format that changes the full size image url into the thumbnail URL.

*KNOWN ISSUE*: VIPERGDS-1585

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
