### PR TITLE
[CI] Update minimum supported viper version to match build8 and remove github reporter

### DIFF
--- a/.github/workflows/yamcs-quickstart-e2e.yml
+++ b/.github/workflows/yamcs-quickstart-e2e.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         yamcs-version:
           - default
-          - 5.8.0 #viper
+          - 5.8.3 #viper
           ## disabling until we get confirmation- 5.3.2 #ab
         openmct-version:
           - latest

--- a/tests/e2e/playwright-quickstart.config.js
+++ b/tests/e2e/playwright-quickstart.config.js
@@ -65,7 +65,6 @@ const config = {
             outputFolder: '../html-test-results' //Must be in different location due to https://github.com/microsoft/playwright/issues/12840
         }],
         ['junit', { outputFile: 'test-results/results.xml' }],
-        ['github'],
         ['@deploysentinel/playwright']
     ]
 };


### PR DESCRIPTION
### Describe your changes:
- Updates the minimum supported version of viper
- Removes noisy playwright github reporter


### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
