### PR TITLE
Add event filters to plugin definition

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -55,7 +55,6 @@ const openmct = window.openmct;
         openmct.install(openmct.plugins.LocalStorage());
         openmct.install(openmct.plugins.Espresso());
         openmct.install(openmct.plugins.MyItems());
-        openmct.install(openmct.plugins.Filters(['telemetry.plot.overlay', 'table']));
         openmct.install(openmct.plugins.example.Generator());
         openmct.install(openmct.plugins.example.ExampleImagery());
         openmct.install(openmct.plugins.UTCTimeSystem());

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -208,5 +208,6 @@ export default function installYamcsPlugin(configuration) {
             configuration.yamcsHistoricalEndpoint,
             configuration.yamcsInstance));
 
+        openmct.install(openmct.plugins.Filters(['telemetry.plot.overlay', 'table']));
     };
 }

--- a/tests/e2e/yamcs/network.e2e.spec.js
+++ b/tests/e2e/yamcs/network.e2e.spec.js
@@ -25,6 +25,7 @@ Network Specific Tests
 */
 
 const { test, expect } = require('../opensource/pluginFixtures');
+const { setFixedTimeMode } = require('../opensource/appActions');
 
 test.describe("Quickstart network requests @yamcs", () => {
     // Collect all request events, specifically for YAMCS
@@ -74,8 +75,7 @@ test.describe("Quickstart network requests @yamcs", () => {
         expect(filteredRequests.length).toBe(3);
 
         // Change to fixed time
-        await page.locator('button:has-text("Local Clock")').click();
-        await page.locator('text="Fixed Timespan"').click();
+        await setFixedTimeMode(page);
 
         await page.waitForLoadState('networkidle');
         networkRequests = [];


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #348 

### Describe your changes:
Add the filters plugin install to the Open MCT YAMCS plugin itself.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
