### PR TITLE
Ensure all data is retrieved for non min maxed requests (when size is provided)

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -58,3 +58,5 @@ export const METADATA_TIME_KEY = 'generationTime';
 export const UNSUPPORTED_TYPE = 'Unsupported Data Type';
 export const AGGREGATE_TYPE = 'AGGREGATE';
 export const NAMESPACE = 'taxonomy';
+
+export const MAX_REQUEST_SIZE = 1000000;

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -19,7 +19,7 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-import { AGGREGATE_TYPE, OBJECT_TYPES, METADATA_TIME_KEY } from '../const';
+import { AGGREGATE_TYPE, OBJECT_TYPES, METADATA_TIME_KEY, MAX_REQUEST_SIZE } from '../const';
 import {
     idToQualifiedName,
     getValue,
@@ -58,7 +58,7 @@ export default class YamcsHistoricalTelemetryProvider {
         options = { ...options };
         this.standardizeOptions(options, domainObject);
         if ((options.strategy === 'latest') && options.timeContext?.isRealTime()) {
-            // Latest requested in realtime, use latest telemetry provider instead
+            // Latest requested in realtime, use the latest telemetry provider instead
             const mctDatum = await this.latestTelemetryProvider.requestLatest(domainObject);
 
             return [mctDatum];
@@ -80,6 +80,9 @@ export default class YamcsHistoricalTelemetryProvider {
             const minMaxHistory = await this.getMinMaxHistory(...requestArguments);
 
             return minMaxHistory;
+        } else {
+            // override the totalRequestSize set in standardizeOptions since we're not minMaxing VIPEROMCT-397
+            options.totalRequestSize = MAX_REQUEST_SIZE;
         }
 
         const history = await this.getHistory(...requestArguments);
@@ -125,7 +128,7 @@ export default class YamcsHistoricalTelemetryProvider {
         options.sizeType = 'limit';
         options.order = 'asc';
         options.isSamples = false;
-        options.totalRequestSize = options.size || 1000000;
+        options.totalRequestSize = options.size || MAX_REQUEST_SIZE;
 
         options.size = this.getAppropriateSize(options.size);
 

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -73,6 +73,13 @@ export default class YamcsHistoricalTelemetryProvider {
             && options.strategy === 'minmax'
             && !hasEnumValue;
 
+        if (!options.isSamples) {
+            // override the totalRequestSize and sizeType set in standardizeOptions since we're not minMaxing VIPEROMCT-397
+            // the sizeType is used in the url creation below
+            options.totalRequestSize = MAX_REQUEST_SIZE;
+            options.sizeType = 'limit';
+        }
+
         const url = this.buildUrl(id, options);
         const requestArguments = [id, url, options];
 
@@ -80,10 +87,6 @@ export default class YamcsHistoricalTelemetryProvider {
             const minMaxHistory = await this.getMinMaxHistory(...requestArguments);
 
             return minMaxHistory;
-        } else {
-            // override the totalRequestSize and sizeType set in standardizeOptions since we're not minMaxing VIPEROMCT-397
-            options.totalRequestSize = MAX_REQUEST_SIZE;
-            options.sizeType = 'limit';
         }
 
         const history = await this.getHistory(...requestArguments);

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -81,8 +81,9 @@ export default class YamcsHistoricalTelemetryProvider {
 
             return minMaxHistory;
         } else {
-            // override the totalRequestSize set in standardizeOptions since we're not minMaxing VIPEROMCT-397
+            // override the totalRequestSize and sizeType set in standardizeOptions since we're not minMaxing VIPEROMCT-397
             options.totalRequestSize = MAX_REQUEST_SIZE;
+            options.sizeType = 'limit';
         }
 
         const history = await this.getHistory(...requestArguments);


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes VIPEROMCT-397

### Describe your changes:
Ignore the request size option if there is no minMaxing (samples). 
Also use the `limit` sizeType as opposed to the `count` size type which is used for the samples endpoint.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
