### PR TITLE
PROTOTYPE: Move WebSocket management to workers

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -86,7 +86,7 @@ const openmct = window.openmct;
         openmct.install(openmct.plugins.Notebook());
         openmct.install(openmct.plugins.LADTable());
         openmct.install(openmct.plugins.ClearData(['table', 'telemetry.plot.overlay', 'telemetry.plot.stacked']));
-
+        openmct.install(openmct.plugins.PerformanceIndicator());
         openmct.install(openmct.plugins.FaultManagement());
     }
 }());

--- a/src/providers/realtime-provider.js
+++ b/src/providers/realtime-provider.js
@@ -1,314 +1,139 @@
-/*****************************************************************************
- * Open MCT, Copyright (c) 2014-2021, United States Government
- * as represented by the Administrator of the National Aeronautics and Space
- * Administration. All rights reserved.
- *
- * Open MCT is licensed under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0.
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- *
- * Open MCT includes source code licensed under additional open source
- * licenses. See the Open Source Licenses file (LICENSES.md) included with
- * this source code distribution or the Licensing information page available
- * at runtime from the About dialog for additional information.
- *****************************************************************************/
+import realtimeWorker from './realtime-worker.js';
 
-import * as MESSAGES from './messages';
-import { OBJECT_TYPES, DATA_TYPES, AGGREGATE_TYPE, METADATA_TIME_KEY, STALENESS_STATUS_MAP } from '../const';
-import {
-    buildStalenessResponseObject,
-    idToQualifiedName,
-    qualifiedNameToId,
-    getValue,
-    addLimitInformation
-} from '../utils.js';
-import { commandToTelemetryDatum } from './commands';
-import { eventToTelemetryDatum } from './events';
-
-const FALLBACK_AND_WAIT_MS = [1000, 5000, 5000, 10000, 10000, 30000];
 export default class RealtimeProvider {
+    #worker;
+    #telemetrySubscribersByParameterName = {};
+    #url;
+    #instance;
+
     constructor(url, instance) {
-        this.url = url;
-        this.instance = instance;
-        this.observingStaleness = {};
-        this.supportedObjectTypes = {};
-        this.supportedDataTypes = {};
-        this.connected = false;
-        this.requests = [];
-        this.currentWaitIndex = 0;
-        this.lastSubscriptionId = 1;
-        this.subscriptionsByCall = new Map();
-        this.subscriptionsById = {};
+        this.#url = url;
+        this.#instance = instance;
+        this.fps = 0;
+        this.currentDebounce = 1000;
 
-        this.addSupportedObjectTypes(Object.values(OBJECT_TYPES));
-        this.addSupportedDataTypes(Object.values(DATA_TYPES));
-    }
-
-    addSupportedObjectTypes(types) {
-        types.forEach(type => this.supportedObjectTypes[type] = type);
-    }
-
-    addSupportedDataTypes(dataTypes) {
-        dataTypes.forEach(dataType => this.supportedDataTypes[dataType] = dataType);
+        this.#measureFPS();
     }
 
     supportsSubscribe(domainObject) {
-        return this.isSupportedObjectType(domainObject.type);
+        return domainObject.type === 'yamcs.telemetry';
     }
 
-    subscribeToStaleness(domainObject, callback) {
-        const qualifiedName = idToQualifiedName(domainObject.identifier.key);
-        this.observingStaleness[qualifiedName] = {
-            response: buildStalenessResponseObject(undefined, 0),
-            callback
-        };
-
-        return () => {
-            delete this.observingStaleness[qualifiedName];
-        };
-    }
-
-    isSupportedObjectType(type) {
-        return this.supportedObjectTypes[type];
-    }
-
-    isSupportedDataType(type) {
-        return this.supportedDataTypes[type];
+    subscribeToStaleness() {
+        return () => { };
     }
 
     subscribe(domainObject, callback) {
-        let subscriptionDetails = this.buildSubscriptionDetails(domainObject, callback);
-        let id = subscriptionDetails.subscriptionId;
-        this.subscriptionsById[id] = subscriptionDetails;
+        const parameterName = idToParameterName(domainObject.identifier.key);
+        const worker = this.#getWorker();
 
-        if (this.connected) {
-            this.sendSubscribeMessage(subscriptionDetails);
-        }
+        worker.postMessage({
+            type: 'subscribe',
+            parameterName: parameterName,
+            debounceStrategy: 'drop' //or 'min-max'?
+        });
+
+        this.#addSubscriberCallback(parameterName, callback);
 
         return () => {
-            this.sendUnsubscribeMessage(subscriptionDetails);
+            this.#removeSubscriberCallback(parameterName, callback);
 
-            if (this.subscriptionsById[id]) {
-                this.subscriptionsByCall.delete(this.subscriptionsById[id].call);
-                delete this.subscriptionsById[id];
-            }
+            worker.postMessage({
+                type: 'unsubscribe',
+                parameterName
+            });
         };
-    }
-
-    buildSubscriptionDetails(domainObject, callback) {
-        let subscriptionId = this.lastSubscriptionId++;
-        let subscriptionDetails = {
-            instance: this.instance,
-            subscriptionId: subscriptionId,
-            name: idToQualifiedName(domainObject.identifier.key),
-            domainObject,
-            updateOnExpiration: true,
-            callback: callback
-        };
-
-        return subscriptionDetails;
-    }
-
-    sendSubscribeMessage(subscriptionDetails) {
-        let domainObject = subscriptionDetails.domainObject;
-        let message = MESSAGES.SUBSCRIBE[domainObject.type](subscriptionDetails);
-
-        this.sendOrQueueMessage(message);
-    }
-
-    sendUnsubscribeMessage(subscriptionDetails) {
-        let message = MESSAGES.UNSUBSCRIBE(subscriptionDetails);
-
-        this.sendOrQueueMessage(message);
-    }
-
-    reconnect() {
-        this.subscriptionsByCall.clear();
-
-        if (this.reconnectTimeout) {
-            return;
-        }
-
-        this.reconnectTimeout = setTimeout(() => {
-            this.connect();
-            delete this.reconnectTimeout;
-        }, FALLBACK_AND_WAIT_MS[this.currentWaitIndex]);
-
-        if (this.currentWaitIndex < FALLBACK_AND_WAIT_MS.length - 1) {
-            this.currentWaitIndex++;
-        }
-    }
-
-    sendOrQueueMessage(request) {
-        if (this.connected) {
-            try {
-                this.sendMessage(request);
-            } catch (error) {
-                this.connected = false;
-                this.requests.push(request);
-                console.error("🚨 Error while attempting to send to websocket, closing websocket", error);
-                this.socket.close();
-            }
-        } else {
-            this.requests.push(request);
-        }
     }
 
     connect() {
-        if (this.connected) {
-            return;
-        }
+        this.#getWorker().postMessage({
+            type: 'connect',
+            url: this.#url,
+            instance: this.#instance
+        });
+    }
+    #measureFPS() {
+        let lastCalculated = performance.now();
+        let frames = 0;
+        let self = this;
+        requestAnimationFrame(incremementFrames);
 
-        let wsUrl = `${this.url}`;
-        this.lastSubscriptionId = 1;
-        this.connected = false;
-        this.socket = new WebSocket(wsUrl);
-
-        this.socket.onopen = () => {
-            clearTimeout(this.reconnectTimeout);
-
-            this.connected = true;
-            console.log(`🔌 Established websocket connection to ${wsUrl}`);
-
-            this.currentWaitIndex = 0;
-            this.resubscribeToAll();
-            this.flushQueue();
-        };
-
-        this.socket.onmessage = (event) => {
-            const message = JSON.parse(event.data);
-
-            if (!this.isSupportedDataType(message.type)) {
-                return;
-            }
-
-            const isReply = message.type === DATA_TYPES.DATA_TYPE_REPLY;
-            let subscriptionDetails;
-
-            if (isReply) {
-                const id = message.data.replyTo;
-                const call = message.call;
-                subscriptionDetails = this.subscriptionsById[id];
-                subscriptionDetails.call = call;
-                this.subscriptionsByCall.set(call, subscriptionDetails);
+        function incremementFrames() {
+            let now = performance.now();
+            if ((now - lastCalculated) < 1000) {
+                frames++;
             } else {
-                subscriptionDetails = this.subscriptionsByCall.get(message.call);
-
-                // possibly cancelled
-                if (!subscriptionDetails) {
-                    return;
-                }
-
-                if (this.isTelemetryMessage(message)) {
-                    let values = message.data.values || [];
-                    let parentName = subscriptionDetails.domainObject.name;
-
-                    values.forEach(parameter => {
-                        let datum = {
-                            id: qualifiedNameToId(subscriptionDetails.name),
-                            timestamp: parameter[METADATA_TIME_KEY]
-                        };
-                        let value = getValue(parameter, parentName);
-
-                        if (this.observingStaleness[subscriptionDetails.name] !== undefined) {
-                            const status = STALENESS_STATUS_MAP[parameter.acquisitionStatus];
-
-                            if (this.observingStaleness[subscriptionDetails.name].response.isStale !== status) {
-                                const stalenesResponseObject = buildStalenessResponseObject(
-                                    status,
-                                    parameter[METADATA_TIME_KEY]
-                                );
-                                this.observingStaleness[subscriptionDetails.name].response = stalenesResponseObject;
-                                this.observingStaleness[subscriptionDetails.name].callback(stalenesResponseObject);
-                            }
-                        }
-
-                        if (parameter.engValue.type !== AGGREGATE_TYPE) {
-                            datum.value = value;
-                        } else {
-                            datum = {
-                                ...datum,
-                                ...value
-                            };
-                        }
-
-                        addLimitInformation(parameter, datum);
-                        subscriptionDetails.callback(datum);
-                    });
-                } else if (this.isCommandMessage(message)) {
-                    const datum = commandToTelemetryDatum(message.data);
-                    subscriptionDetails.callback(datum);
-                } else if (this.isEventMessage(message)) {
-                    const datum = eventToTelemetryDatum(message.data);
-                    subscriptionDetails.callback(datum);
-                } else {
-                    subscriptionDetails.callback(message.data);
-                }
-            }
-        };
-
-        this.socket.onerror = (error) => {
-            console.error(`🚨 Websocket error, closing websocket`, error);
-            this.socket.close();
-        };
-
-        this.socket.onclose = () => {
-            console.warn('🚪 Websocket closed. Attempting to reconnect...');
-            this.connected = false;
-            this.socket = null;
-
-            this.reconnect();
-        };
-    }
-
-    resubscribeToAll() {
-        Object.values(this.subscriptionsById).forEach((subscriptionDetails) => {
-            this.sendSubscribeMessage(subscriptionDetails);
-        });
-    }
-
-    flushQueue() {
-        let shouldCloseWebsocket = false;
-        this.requests = this.requests.filter((request) => {
-            try {
-                this.sendMessage(request);
-            } catch (error) {
-                this.connected = false;
-                console.error('🚨 Error while attempting to send to websocket, closing websocket', error);
-
-                shouldCloseWebsocket = true;
-
-                return true;
+                self.fps = frames;
+                lastCalculated = now;
+                frames = 1;
             }
 
-            return false;
-        });
+            requestAnimationFrame(incremementFrames);
+        }
 
-        if (shouldCloseWebsocket) {
-            this.socket.close();
+    }
+
+    #getWorker() {
+        if (this.#worker === undefined) {
+            const workerFunction = `(${realtimeWorker.toString()})()`;
+            const workerBlob = new Blob([workerFunction]);
+            const workerUrl = URL.createObjectURL(workerBlob, { type: 'application/javascript' });
+            this.#worker = new Worker(workerUrl);
+            this.#worker.addEventListener("message", (message) => {
+                this.#routeToHandler(message.data);
+            });
+            // eslint-disable-next-line func-style
+            const adjustDebounce = () => {
+                const fps = this.fps;
+                const targetFps = 40;
+                const difference = targetFps - fps;
+                if (difference < 0) {
+                    this.currentDebounce = Math.max(this.currentDebounce - 100, 0);
+                } else if (difference > 0) {
+                    this.currentDebounce = Math.min(this.currentDebounce + 100, 1000);
+                }
+
+                this.#worker.postMessage({
+                    type: 'debounce',
+                    debounce: Math.min(this.currentDebounce, 1000)
+                });
+
+                setTimeout(adjustDebounce, 1000);
+            };
+
+            adjustDebounce();
+            // Implement throttling here
+
+            // this.#worker.postMessage({
+            //     type: 'debounce',
+            //     debounce: 500
+            // });
+        }
+
+        return this.#worker;
+    }
+
+    #routeToHandler(message) {
+        this.#informTelemtrySubscribers(message);
+    }
+
+    #informTelemtrySubscribers(message) {
+        const telemetrySubscriber = this.#telemetrySubscribersByParameterName[message.parameterName];
+        if (telemetrySubscriber) {
+            telemetrySubscriber(message.datum);
         }
     }
 
-    sendMessage(message) {
-        this.socket.send(message);
+    #addSubscriberCallback(parameterName, callback) {
+        this.#telemetrySubscribersByParameterName[parameterName] = callback;
     }
 
-    isTelemetryMessage(message) {
-        return message.type === 'parameters';
+    #removeSubscriberCallback(parameterName) {
+        delete this.#telemetrySubscribersByParameterName[parameterName];
     }
 
-    isCommandMessage(message) {
-        return message.type === 'commands';
-    }
+}
 
-    isEventMessage(message) {
-        return message.type === 'events';
-    }
+function idToParameterName(id) {
+    return id.replace(/~/g, '/');
 }

--- a/src/providers/realtime-provider.old.js
+++ b/src/providers/realtime-provider.old.js
@@ -1,0 +1,314 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2021, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+import * as MESSAGES from './messages';
+import { OBJECT_TYPES, DATA_TYPES, AGGREGATE_TYPE, METADATA_TIME_KEY, STALENESS_STATUS_MAP } from '../const';
+import {
+    buildStalenessResponseObject,
+    idToQualifiedName,
+    qualifiedNameToId,
+    getValue,
+    addLimitInformation
+} from '../utils.js';
+import { commandToTelemetryDatum } from './commands';
+import { eventToTelemetryDatum } from './events';
+
+const FALLBACK_AND_WAIT_MS = [1000, 5000, 5000, 10000, 10000, 30000];
+export default class RealtimeProvider {
+    constructor(url, instance) {
+        this.url = url;
+        this.instance = instance;
+        this.observingStaleness = {};
+        this.supportedObjectTypes = {};
+        this.supportedDataTypes = {};
+        this.connected = false;
+        this.requests = [];
+        this.currentWaitIndex = 0;
+        this.lastSubscriptionId = 1;
+        this.subscriptionsByCall = new Map();
+        this.subscriptionsById = {};
+
+        this.addSupportedObjectTypes(Object.values(OBJECT_TYPES));
+        this.addSupportedDataTypes(Object.values(DATA_TYPES));
+    }
+
+    addSupportedObjectTypes(types) {
+        types.forEach(type => this.supportedObjectTypes[type] = type);
+    }
+
+    addSupportedDataTypes(dataTypes) {
+        dataTypes.forEach(dataType => this.supportedDataTypes[dataType] = dataType);
+    }
+
+    supportsSubscribe(domainObject) {
+        return this.isSupportedObjectType(domainObject.type);
+    }
+
+    subscribeToStaleness(domainObject, callback) {
+        const qualifiedName = idToQualifiedName(domainObject.identifier.key);
+        this.observingStaleness[qualifiedName] = {
+            response: buildStalenessResponseObject(undefined, 0),
+            callback
+        };
+
+        return () => {
+            delete this.observingStaleness[qualifiedName];
+        };
+    }
+
+    isSupportedObjectType(type) {
+        return this.supportedObjectTypes[type];
+    }
+
+    isSupportedDataType(type) {
+        return this.supportedDataTypes[type];
+    }
+
+    subscribe(domainObject, callback) {
+        let subscriptionDetails = this.buildSubscriptionDetails(domainObject, callback);
+        let id = subscriptionDetails.subscriptionId;
+        this.subscriptionsById[id] = subscriptionDetails;
+
+        if (this.connected) {
+            this.sendSubscribeMessage(subscriptionDetails);
+        }
+
+        return () => {
+            this.sendUnsubscribeMessage(subscriptionDetails);
+
+            if (this.subscriptionsById[id]) {
+                this.subscriptionsByCall.delete(this.subscriptionsById[id].call);
+                delete this.subscriptionsById[id];
+            }
+        };
+    }
+
+    buildSubscriptionDetails(domainObject, callback) {
+        let subscriptionId = this.lastSubscriptionId++;
+        let subscriptionDetails = {
+            instance: this.instance,
+            subscriptionId: subscriptionId,
+            name: idToQualifiedName(domainObject.identifier.key),
+            domainObject,
+            updateOnExpiration: true,
+            callback: callback
+        };
+
+        return subscriptionDetails;
+    }
+
+    sendSubscribeMessage(subscriptionDetails) {
+        let domainObject = subscriptionDetails.domainObject;
+        let message = MESSAGES.SUBSCRIBE[domainObject.type](subscriptionDetails);
+
+        this.sendOrQueueMessage(message);
+    }
+
+    sendUnsubscribeMessage(subscriptionDetails) {
+        let message = MESSAGES.UNSUBSCRIBE(subscriptionDetails);
+
+        this.sendOrQueueMessage(message);
+    }
+
+    reconnect() {
+        this.subscriptionsByCall.clear();
+
+        if (this.reconnectTimeout) {
+            return;
+        }
+
+        this.reconnectTimeout = setTimeout(() => {
+            this.connect();
+            delete this.reconnectTimeout;
+        }, FALLBACK_AND_WAIT_MS[this.currentWaitIndex]);
+
+        if (this.currentWaitIndex < FALLBACK_AND_WAIT_MS.length - 1) {
+            this.currentWaitIndex++;
+        }
+    }
+
+    sendOrQueueMessage(request) {
+        if (this.connected) {
+            try {
+                this.sendMessage(request);
+            } catch (error) {
+                this.connected = false;
+                this.requests.push(request);
+                console.error("🚨 Error while attempting to send to websocket, closing websocket", error);
+                this.socket.close();
+            }
+        } else {
+            this.requests.push(request);
+        }
+    }
+
+    connect() {
+        if (this.connected) {
+            return;
+        }
+
+        let wsUrl = `${this.url}`;
+        this.lastSubscriptionId = 1;
+        this.connected = false;
+        this.socket = new WebSocket(wsUrl);
+
+        this.socket.onopen = () => {
+            clearTimeout(this.reconnectTimeout);
+
+            this.connected = true;
+            console.log(`🔌 Established websocket connection to ${wsUrl}`);
+
+            this.currentWaitIndex = 0;
+            this.resubscribeToAll();
+            this.flushQueue();
+        };
+
+        this.socket.onmessage = (event) => {
+            const message = JSON.parse(event.data);
+
+            if (!this.isSupportedDataType(message.type)) {
+                return;
+            }
+
+            const isReply = message.type === DATA_TYPES.DATA_TYPE_REPLY;
+            let subscriptionDetails;
+
+            if (isReply) {
+                const id = message.data.replyTo;
+                const call = message.call;
+                subscriptionDetails = this.subscriptionsById[id];
+                subscriptionDetails.call = call;
+                this.subscriptionsByCall.set(call, subscriptionDetails);
+            } else {
+                subscriptionDetails = this.subscriptionsByCall.get(message.call);
+
+                // possibly cancelled
+                if (!subscriptionDetails) {
+                    return;
+                }
+
+                if (this.isTelemetryMessage(message)) {
+                    let values = message.data.values || [];
+                    let parentName = subscriptionDetails.domainObject.name;
+
+                    values.forEach(parameter => {
+                        let datum = {
+                            id: qualifiedNameToId(subscriptionDetails.name),
+                            timestamp: parameter[METADATA_TIME_KEY]
+                        };
+                        let value = getValue(parameter, parentName);
+
+                        if (this.observingStaleness[subscriptionDetails.name] !== undefined) {
+                            const status = STALENESS_STATUS_MAP[parameter.acquisitionStatus];
+
+                            if (this.observingStaleness[subscriptionDetails.name].response.isStale !== status) {
+                                const stalenesResponseObject = buildStalenessResponseObject(
+                                    status,
+                                    parameter[METADATA_TIME_KEY]
+                                );
+                                this.observingStaleness[subscriptionDetails.name].response = stalenesResponseObject;
+                                this.observingStaleness[subscriptionDetails.name].callback(stalenesResponseObject);
+                            }
+                        }
+
+                        if (parameter.engValue.type !== AGGREGATE_TYPE) {
+                            datum.value = value;
+                        } else {
+                            datum = {
+                                ...datum,
+                                ...value
+                            };
+                        }
+
+                        addLimitInformation(parameter, datum);
+                        subscriptionDetails.callback(datum);
+                    });
+                } else if (this.isCommandMessage(message)) {
+                    const datum = commandToTelemetryDatum(message.data);
+                    subscriptionDetails.callback(datum);
+                } else if (this.isEventMessage(message)) {
+                    const datum = eventToTelemetryDatum(message.data);
+                    subscriptionDetails.callback(datum);
+                } else {
+                    subscriptionDetails.callback(message.data);
+                }
+            }
+        };
+
+        this.socket.onerror = (error) => {
+            console.error(`🚨 Websocket error, closing websocket`, error);
+            this.socket.close();
+        };
+
+        this.socket.onclose = () => {
+            console.warn('🚪 Websocket closed. Attempting to reconnect...');
+            this.connected = false;
+            this.socket = null;
+
+            this.reconnect();
+        };
+    }
+
+    resubscribeToAll() {
+        Object.values(this.subscriptionsById).forEach((subscriptionDetails) => {
+            this.sendSubscribeMessage(subscriptionDetails);
+        });
+    }
+
+    flushQueue() {
+        let shouldCloseWebsocket = false;
+        this.requests = this.requests.filter((request) => {
+            try {
+                this.sendMessage(request);
+            } catch (error) {
+                this.connected = false;
+                console.error('🚨 Error while attempting to send to websocket, closing websocket', error);
+
+                shouldCloseWebsocket = true;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        if (shouldCloseWebsocket) {
+            this.socket.close();
+        }
+    }
+
+    sendMessage(message) {
+        this.socket.send(message);
+    }
+
+    isTelemetryMessage(message) {
+        return message.type === 'parameters';
+    }
+
+    isCommandMessage(message) {
+        return message.type === 'commands';
+    }
+
+    isEventMessage(message) {
+        return message.type === 'events';
+    }
+}

--- a/src/providers/realtime-worker.js
+++ b/src/providers/realtime-worker.js
@@ -1,0 +1,187 @@
+export default function installRealtimeWorker() {
+    const VALUE_EXTRACT_MAP = {
+        'UINT64': (value) => value.uint64Value,
+        'INT64': (value) => value.int64Value,
+        'SINT64': (value) => value.sint64Value,
+        'UINT32': (value) => value.uint32Value,
+        'INT32': (value) => value.int32Value,
+        'SINT32': (value) => value.sint32Value,
+        'UINT16': (value) => value.uint16Value,
+        'INT16': (value) => value.int16Value,
+        'SINT16': (value) => value.sint16Value,
+        'FLOAT': (value) => value.floatValue,
+        'DOUBLE': (value) => value.doubleValue,
+        'STRING': (value) => value.stringValue,
+        'ENUMERATED': (value) => value.stringValue,
+        'TIMESTAMP': (value) => value.stringValue,
+        'BOOLEAN': (value) => value.booleanValue,
+        'BINARY': (value) => value.binaryValue
+    };
+
+    class RealtimeWorker {
+        #socket;
+        #workerHandle;
+        #instance;
+        #lastSusbcriptionId = 1;
+
+        // The Yamcs WebSocket architecture forces us to key by all of these.
+        #subscriptionDetailsById = {};
+        #subscriptionDetailsByCall = {};
+        #subscriptionDetailsByParameterName = {};
+        #latestDataTable = {};
+        #debouncePeriod = 1000;
+
+        #messageQueue = [];
+
+        constructor(workerHandle) {
+            this.#workerHandle = workerHandle;
+            this.flushLatestDataTable = this.flushLatestDataTable.bind(this);
+        }
+
+        connect(url, instance) {
+            this.#socket = new WebSocket(url);
+            this.#instance = instance;
+            this.#socket.addEventListener('message', (event) => {
+                const message = JSON.parse(event.data);
+                this.routeSocketMessageToHandler(message);
+            });
+            this.#socket.addEventListener('open', () => {
+                this.flushLatestDataTable();
+                this.#messageQueue.forEach((message) => {
+                    this.#socket.send(JSON.stringify(message));
+                });
+            });
+        }
+
+        subscribe(parameterName) {
+            const subscriptionId = this.#newSubcriptionId();
+            const subscriptionDetails = {
+                parameterName: parameterName,
+                subscriptionId: subscriptionId
+            };
+
+            this.#subscriptionDetailsByParameterName[parameterName] = subscriptionDetails;
+            this.#subscriptionDetailsById[subscriptionId] = subscriptionDetails;
+
+            this.#sendMessage({
+                "type": "parameters",
+                "id": subscriptionId,
+                "options": {
+                    "instance": this.#instance,
+                    "processor": "realtime",
+                    "id": [{
+                        "name": parameterName
+                    }],
+                    "sendFromCache": true,
+                    "updateOnExpiration": true
+                }
+            });
+        }
+        unsubscribe(parameterName) {
+            const subscriptionDetails = this.#subscriptionDetailsByParameterName[parameterName];
+            const call = subscriptionDetails.call;
+
+            this.#sendMessage({
+                "type": "cancel",
+                "options": {
+                    "call": call
+                }
+            });
+            delete this.#subscriptionDetailsByCall[subscriptionDetails.call];
+            delete this.#subscriptionDetailsById[subscriptionDetails.subscriptionId];
+            delete this.#subscriptionDetailsByParameterName[subscriptionDetails.parameterName];
+        }
+        debounce(message) {
+            const debouncePeriod = message.data.debounce;
+            this.#debouncePeriod = debouncePeriod;
+        }
+
+        routeSocketMessageToHandler(socketMessage) {
+            switch (socketMessage.type) {
+            case 'reply':
+                this.#setCallForSubscription(socketMessage);
+                break;
+            case 'parameters':
+                this.processReceivedParameter(socketMessage);
+                break;
+            }
+        }
+
+        routeWorkerMessageToHandler(workerMessage) {
+            switch (workerMessage.data.type) {
+            case 'connect':
+                this.connect(workerMessage.data.url, workerMessage.data.instance);
+                break;
+            case 'subscribe':
+                this.subscribe(workerMessage.data.parameterName, workerMessage.data.debounceStrategy);
+                break;
+            case 'unsubscribe':
+                this.unsubscribe(workerMessage.data.parameterName);
+                break;
+            case 'debounce':
+                this.debounce(workerMessage);
+            }
+        }
+
+        processReceivedParameter(parameterMessage) {
+            parameterMessage.data.values.forEach((parameterValue) => {
+                this.#latestDataTable[parameterMessage.call] = parameterValue;
+            });
+        }
+
+        flushLatestDataTable() {
+            const latestDataTable = this.#latestDataTable;
+            Object.entries(latestDataTable).forEach(([call, parameterValue]) => {
+                const {parameterName, datum} = this.#parseDatum(parameterValue, call);
+                this.#workerHandle.postMessage({
+                    type: 'parameter',
+                    parameterName,
+                    datum
+                });
+                delete latestDataTable[call];
+            });
+            setTimeout(this.flushLatestDataTable, this.#debouncePeriod);
+        }
+
+        #sendMessage(message) {
+            if (this.#socket.readyState === WebSocket.OPEN) {
+                this.#socket.send(JSON.stringify(message));
+            } else {
+                this.#messageQueue.push(message);
+            }
+        }
+
+        #parseDatum(parameterValue, call) {
+            const subscriptionDetails = this.#subscriptionDetailsByCall[call];
+            const datum = {
+                timestamp: parameterValue.generationTime,
+                timestampParsed: Date.parse(parameterValue.generationTime),
+                value: VALUE_EXTRACT_MAP[parameterValue.engValue.type](parameterValue.engValue)
+            };
+
+            return {
+                parameterName: subscriptionDetails.parameterName,
+                datum
+            };
+        }
+
+        #setCallForSubscription(subscriptionMessage) {
+            const subscriptionDetails = this.#subscriptionDetailsById[subscriptionMessage.data.replyTo];
+            const call = subscriptionMessage.call;
+
+            subscriptionDetails.call = call;
+            this.#subscriptionDetailsByCall[call] = subscriptionDetails;
+
+        }
+
+        #newSubcriptionId() {
+            return this.#lastSusbcriptionId++;
+        }
+    }
+
+    const worker = new RealtimeWorker(self);
+
+    self.addEventListener('message', (message) => {
+        worker.routeWorkerMessageToHandler(message);
+    });
+}


### PR DESCRIPTION
### Describe your changes:

A branch with a prototype implementation of WebSocket management from workers. In this prototype the RealtimeProvider is modified to move the responsibility of managing the lifecycle and events of a WebSocket object to a web worker, which has the effect of moving it off of the UI thread.