### PR TITLE
Add script to exercise YAMCS' `writeBufferWaterMark`

### DIFF
--- a/tests/overflowYamcs/README.md
+++ b/tests/overflowYamcs/README.md
@@ -1,0 +1,25 @@
+# Purpose
+
+This directory is to test YAMCS setting for large binary types, and its interaction with the [writeBufferWaterMark](https://docs.yamcs.org/yamcs-server-manual/services/global/http-server/), detailed in this [ticket](https://github.com/akhenry/openmct-yamcs/issues/397). Setting the `writeBufferWaterMark` to a value in bytes lower than the file you will send using this script will prevent you from seeing the value on the [YAMCS webpage](http://localhost:8090/telemetry/parameters/%2Fmyproject%2FBigPicture/summary?c=myproject__realtime).
+
+# To Run
+1. Install the provided `xtce.xml` in this directory in the [YAMCS Quickstart directory](src/main/yamcs/mdb/xtce.xml) in `src/main/yamcs/mdb/xtce.xml`
+2. Set the `writeBufferMark` to a value that's smaller in bytes than the image you plan to use. E.g. for ~1.5MB:
+```yaml
+services:
+  - class: org.yamcs.http.HttpServer
+    args:
+      port: 8090
+      address: "0.0.0.0"
+      cors:
+        allowOrigin: "*"
+        allowCredentials: false
+      maxContentLength: 20000000
+      webSocket:
+        writeBufferWaterMark: { low: 32768, high: 1600000 }
+```
+3. Start YAMCS Quickstart: `mvn yamcs:run`
+4. Inspect the script, and adjust the top constants to your liking.
+5. Run the script: `node sendYamcsBinary.mjs`
+6. Observe on [YAMCS webpage](http://localhost:8090/telemetry/parameters/%2Fmyproject%2FBigPicture/summary?c=myproject__realtime) that you can't see the parameter value.
+7. Set the `writeBufferMark`, and reload YAMCS. Notice you can now see the parameter value.

--- a/tests/overflowYamcs/sendYamcsBinary.mjs
+++ b/tests/overflowYamcs/sendYamcsBinary.mjs
@@ -1,0 +1,45 @@
+import { promises as fsPromises } from 'fs';
+
+const IMAGE_PATH = './big_flower.jpg';
+
+const YAMCS_HOST = 'http://localhost:8090';
+const YAMCS_INSTANCE = 'myproject';
+const YAMCS_PROCESSOR = 'realtime';
+const PARAMETER_FQN = '/myproject/BigPicture';
+
+async function sendImageToYamcs(imagePath) {
+    try {
+    // Read the image file and convert it to Base64
+        const imageData = await fsPromises.readFile(imagePath);
+        const base64Image = imageData.toString('base64');
+        // Log the binary data size, just for reference
+        console.debug(`🖼️ Image data size in bytes: ${imageData.length}`);
+
+        // Setting the parameter via Yamcs REST API
+        const endpointUrl = `${YAMCS_HOST}/api/processors/${YAMCS_INSTANCE}/${YAMCS_PROCESSOR}/parameters${PARAMETER_FQN}`;
+        const requestBody = {
+            type: 'BINARY',
+            binaryValue: base64Image
+        };
+
+        console.debug(`📞 Sending data to ${endpointUrl}`);
+
+        const response = await fetch(endpointUrl, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(requestBody)
+        });
+
+        if (!response.ok) {
+            throw new Error(`Error from YAMCS: ${response.statusText}`);
+        }
+
+        console.info('🎉 Parameter set successfully');
+    } catch (error) {
+        console.error('🚨 Error setting parameter:', error.message);
+    }
+}
+
+sendImageToYamcs(IMAGE_PATH);

--- a/tests/overflowYamcs/xtce.xml
+++ b/tests/overflowYamcs/xtce.xml
@@ -1,0 +1,367 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SpaceSystem name="myproject" xmlns="http://www.omg.org/spec/XTCE/20180204" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.omg.org/spec/XTCE/20180204 https://www.omg.org/spec/XTCE/20180204/SpaceSystem.xsd">
+	<TelemetryMetaData>
+		<ParameterTypeSet>
+			<AggregateParameterType name="CCSDS_Packet_ID_Type">
+				<MemberList>
+					<Member name="Version" typeRef="CCSDS_Version_Type" />
+					<Member name="Type" typeRef="CCSDS_Type_Type" />
+					<Member name="SecHdrFlag" typeRef="CCSDS_Sec_Hdr_Flag_Type" />
+					<Member name="APID" typeRef="CCSDS_APID_Type" />
+				</MemberList>
+			</AggregateParameterType>
+			<IntegerParameterType name="CCSDS_Version_Type" signed="false">
+				<UnitSet />
+				<IntegerDataEncoding sizeInBits="3" />
+			</IntegerParameterType>
+			<BooleanParameterType name="CCSDS_Type_Type" zeroStringValue="TM" oneStringValue="TC">
+				<UnitSet />
+				<IntegerDataEncoding sizeInBits="1" />
+			</BooleanParameterType>
+			<BooleanParameterType name="CCSDS_Sec_Hdr_Flag_Type" zeroStringValue="NotPresent" oneStringValue="Present">
+				<UnitSet />
+				<IntegerDataEncoding sizeInBits="1" />
+			</BooleanParameterType>
+			<IntegerParameterType name="CCSDS_APID_Type" signed="false">
+				<UnitSet />
+				<IntegerDataEncoding sizeInBits="11" />
+			</IntegerParameterType>
+			<AggregateParameterType name="CCSDS_Packet_Sequence_Type">
+				<MemberList>
+					<Member name="GroupFlags" typeRef="CCSDS_Group_Flags_Type" />
+					<Member name="Count" typeRef="CCSDS_Source_Sequence_Count_Type" />
+				</MemberList>
+			</AggregateParameterType>
+			<EnumeratedParameterType name="CCSDS_Group_Flags_Type">
+				<UnitSet />
+				<IntegerDataEncoding sizeInBits="2" />
+				<EnumerationList>
+					<Enumeration value="0" label="Continuation" />
+					<Enumeration value="1" label="First" />
+					<Enumeration value="2" label="Last" />
+					<Enumeration value="3" label="Standalone" />
+				</EnumerationList>
+			</EnumeratedParameterType>
+			<IntegerParameterType name="CCSDS_Source_Sequence_Count_Type" signed="false">
+				<UnitSet />
+				<IntegerDataEncoding sizeInBits="14" />
+			</IntegerParameterType>
+			<IntegerParameterType name="CCSDS_Packet_Length_Type" signed="false" initialValue="0">
+				<UnitSet>
+					<Unit description="Size">Octets</Unit>
+				</UnitSet>
+				<IntegerDataEncoding sizeInBits="16" />
+			</IntegerParameterType>
+			<IntegerParameterType name="uint32_t" signed="false">
+				<UnitSet />
+				<IntegerDataEncoding encoding="unsigned" sizeInBits="32" />
+			</IntegerParameterType>
+			<FloatParameterType name="float_t">
+				<UnitSet />
+				<FloatDataEncoding sizeInBits="32" />
+			</FloatParameterType>
+			<BooleanParameterType name="bool_t">
+				<UnitSet />
+				<IntegerDataEncoding sizeInBits="8" />
+			</BooleanParameterType>
+			<AggregateParameterType name="vec3_t">
+				<MemberList>
+					<Member name="x" typeRef="float_t" />
+					<Member name="y" typeRef="float_t" />
+					<Member name="z" typeRef="float_t" />
+				</MemberList>
+			</AggregateParameterType>
+			<EnumeratedParameterType name="EnumerationTest">
+				<UnitSet />
+				<IntegerDataEncoding sizeInBits="3" />
+				<EnumerationList>
+					<Enumeration value="0" label="ENUM_VALUE_0" />
+					<Enumeration value="1" label="ENUM_VALUE_1" />
+					<Enumeration value="2" label="ENUM_VALUE_2" />
+					<Enumeration value="3" label="ENUM_VALUE_3" />
+					<Enumeration value="4" label="ENUM_VALUE_4" />
+					<Enumeration value="5" label="ENUM_VALUE_5" />
+					<Enumeration value="6" label="ENUM_VALUE_6" />
+					<Enumeration value="7" label="ENUM_VALUE_7" />
+				</EnumerationList>
+			</EnumeratedParameterType>
+			<FloatParameterType name="float_t_sunsensor">
+				<UnitSet>
+				  <Unit description="volts"/>
+				</UnitSet>
+				<FloatDataEncoding sizeInBits="32" />
+				<DefaultAlarm>
+					<StaticAlarmRanges>
+					  <WatchRange minInclusive="1" maxExclusive="1.1"/>
+					  <WarningRange minInclusive="1.1" maxExclusive="1.2"/>
+					  <DistressRange minInclusive="1.2" maxExclusive="1.3"/>
+					  <CriticalRange minInclusive="1.4"/>
+					</StaticAlarmRanges>
+				  </DefaultAlarm>
+			  </FloatParameterType>
+			  <BinaryParameterType name="large_binary_t">
+				<BinaryDataEncoding>
+					<SizeInBits>
+						<FixedValue>16777216</FixedValue>  <!-- 2MB as bits: 2 * 1024 * 1024 * 8 -->
+					</SizeInBits>
+				</BinaryDataEncoding>
+            </BinaryParameterType>
+		</ParameterTypeSet>
+		<ParameterSet>
+			<Parameter name="CCSDS_Packet_ID" parameterTypeRef="CCSDS_Packet_ID_Type" />
+			<Parameter name="CCSDS_Packet_Sequence" parameterTypeRef="CCSDS_Packet_Sequence_Type" />
+			<Parameter name="CCSDS_Packet_Length" parameterTypeRef="CCSDS_Packet_Length_Type" />
+			<Parameter name="EpochUSNO" parameterTypeRef="float_t" />
+			<Parameter name="OrbitNumberCumulative" parameterTypeRef="uint32_t" />
+			<Parameter name="ElapsedSeconds" parameterTypeRef="uint32_t" />
+			<Parameter name="A" parameterTypeRef="float_t" />
+			<Parameter name="Height" parameterTypeRef="float_t" />
+			<Parameter name="Position" parameterTypeRef="vec3_t" />
+			<Parameter name="Velocity" parameterTypeRef="vec3_t" />
+			<Parameter name="Latitude" parameterTypeRef="float_t" />
+			<Parameter name="Longitude" parameterTypeRef="float_t" />
+			<Parameter name="Battery1_Voltage" parameterTypeRef="float_t" />
+			<Parameter name="Battery2_Voltage" parameterTypeRef="float_t" />
+			<Parameter name="Battery1_Temp" parameterTypeRef="float_t" />
+			<Parameter name="Battery2_Temp" parameterTypeRef="float_t" />
+			<Parameter name="BigPicture" parameterTypeRef="large_binary_t">
+				<ParameterProperties dataSource="local"/>
+			</Parameter>
+			<Parameter name="Magnetometer" parameterTypeRef="vec3_t" />
+			<Parameter name="Sunsensor" parameterTypeRef="float_t_sunsensor"/>
+			<Parameter name="Gyro" parameterTypeRef="vec3_t" />
+			<Parameter name="Detector_Temp" parameterTypeRef="float_t" />
+			<Parameter name="Shadow" parameterTypeRef="bool_t" />
+			<Parameter name="Contact_Golbasi_GS" parameterTypeRef="bool_t" />
+			<Parameter name="Contact_Svalbard" parameterTypeRef="bool_t" />
+			<Parameter name="Payload_Status" parameterTypeRef="bool_t" />
+			<Parameter name="Payload_Error_Flag" parameterTypeRef="bool_t" />
+			<Parameter name="ADCS_Error_Flag" parameterTypeRef="bool_t" />
+			<Parameter name="CDHS_Error_Flag" parameterTypeRef="bool_t" />
+			<Parameter name="COMMS_Error_Flag" parameterTypeRef="bool_t" />
+			<Parameter name="EPS_Error_Flag" parameterTypeRef="bool_t" />
+			<Parameter name="COMMS_Status" parameterTypeRef="bool_t" />
+			<Parameter name="CDHS_Status" parameterTypeRef="bool_t" />
+			<Parameter name="Mode_Night" parameterTypeRef="bool_t" />
+			<Parameter name="Mode_Day" parameterTypeRef="bool_t" />
+			<Parameter name="Mode_Payload" parameterTypeRef="bool_t" />
+			<Parameter name="Mode_XBand" parameterTypeRef="bool_t" />
+			<Parameter name="Mode_SBand" parameterTypeRef="bool_t" />
+			<Parameter name="Mode_Safe" parameterTypeRef="bool_t" />
+
+			<Parameter name="Enum_Para_1" parameterTypeRef="EnumerationTest" />
+			<Parameter name="Enum_Para_2" parameterTypeRef="EnumerationTest" />
+			<Parameter name="Enum_Para_3" parameterTypeRef="EnumerationTest" />
+		</ParameterSet>
+		<ContainerSet>
+			<SequenceContainer abstract="true" name="CCSDSPacket">
+				<EntryList>
+					<ParameterRefEntry parameterRef="CCSDS_Packet_ID" />
+					<ParameterRefEntry parameterRef="CCSDS_Packet_Sequence" />
+					<ParameterRefEntry parameterRef="CCSDS_Packet_Length" />
+				</EntryList>
+			</SequenceContainer>
+			<SequenceContainer name="TelemetryPacket">
+				<EntryList />
+				<BaseContainer containerRef="CCSDSPacket">
+					<RestrictionCriteria>
+						<ComparisonList>
+							<Comparison value="0" parameterRef="CCSDS_Packet_ID/Version" />
+							<Comparison value="TM" parameterRef="CCSDS_Packet_ID/Type" />
+						</ComparisonList>
+					</RestrictionCriteria>
+				</BaseContainer>
+			</SequenceContainer>
+			<SequenceContainer name="Spacecraft">
+				<EntryList>
+					<ParameterRefEntry parameterRef="EpochUSNO" />
+					<ParameterRefEntry parameterRef="OrbitNumberCumulative" />
+					<ParameterRefEntry parameterRef="ElapsedSeconds" />
+					<ParameterRefEntry parameterRef="A" />
+					<ParameterRefEntry parameterRef="Height" />
+					<ParameterRefEntry parameterRef="Position" />
+					<ParameterRefEntry parameterRef="Velocity" />
+					<ParameterRefEntry parameterRef="Latitude" />
+					<ParameterRefEntry parameterRef="Longitude" />
+					<ParameterRefEntry parameterRef="Battery1_Voltage" />
+					<ParameterRefEntry parameterRef="Battery2_Voltage" />
+					<ParameterRefEntry parameterRef="Battery1_Temp" />
+					<ParameterRefEntry parameterRef="Battery2_Temp" />
+					<ParameterRefEntry parameterRef="Magnetometer" />
+					<ParameterRefEntry parameterRef="Sunsensor" />
+					<ParameterRefEntry parameterRef="Gyro" />
+					<ParameterRefEntry parameterRef="Detector_Temp" />
+					<ParameterRefEntry parameterRef="Shadow" />
+					<ParameterRefEntry parameterRef="Contact_Golbasi_GS" />
+					<ParameterRefEntry parameterRef="Contact_Svalbard" />
+					<ParameterRefEntry parameterRef="Payload_Status" />
+					<ParameterRefEntry parameterRef="Payload_Error_Flag" />
+					<ParameterRefEntry parameterRef="ADCS_Error_Flag" />
+					<ParameterRefEntry parameterRef="CDHS_Error_Flag" />
+					<ParameterRefEntry parameterRef="COMMS_Error_Flag" />
+					<ParameterRefEntry parameterRef="EPS_Error_Flag" />
+					<ParameterRefEntry parameterRef="COMMS_Status" />
+					<ParameterRefEntry parameterRef="CDHS_Status" />
+					<ParameterRefEntry parameterRef="Mode_Night" />
+					<ParameterRefEntry parameterRef="Mode_Day" />
+					<ParameterRefEntry parameterRef="Mode_Payload" />
+					<ParameterRefEntry parameterRef="Mode_XBand" />
+					<ParameterRefEntry parameterRef="Mode_SBand" />
+					<ParameterRefEntry parameterRef="Mode_Safe" />
+					<ParameterRefEntry parameterRef="Enum_Para_1">
+						<LocationInContainerInBits referenceLocation="containerStart">
+							<FixedValue>29</FixedValue>
+						</LocationInContainerInBits>
+					</ParameterRefEntry>
+					<ParameterRefEntry parameterRef="Enum_Para_2">
+						<LocationInContainerInBits referenceLocation="containerStart">
+							<FixedValue>27</FixedValue>
+						</LocationInContainerInBits>
+					</ParameterRefEntry>
+					<ParameterRefEntry parameterRef="Enum_Para_3">
+						<LocationInContainerInBits referenceLocation="containerStart">
+							<FixedValue>25</FixedValue>
+						</LocationInContainerInBits>
+					</ParameterRefEntry>
+				</EntryList>
+				<BaseContainer containerRef="TelemetryPacket">
+					<RestrictionCriteria>
+						<ComparisonList>
+							<Comparison value="NotPresent" parameterRef="CCSDS_Packet_ID/SecHdrFlag" />
+							<Comparison value="100" parameterRef="CCSDS_Packet_ID/APID" />
+						</ComparisonList>
+					</RestrictionCriteria>
+				</BaseContainer>
+			</SequenceContainer>
+		</ContainerSet>
+	</TelemetryMetaData>
+	<CommandMetaData>
+		<ArgumentTypeSet>
+			<IntegerArgumentType name="CCSDS_Version_Type" signed="false">
+				<UnitSet />
+				<IntegerDataEncoding sizeInBits="3" />
+			</IntegerArgumentType>
+			<BooleanArgumentType name="CCSDS_Type_Type" zeroStringValue="TM" oneStringValue="TC">
+				<UnitSet />
+				<IntegerDataEncoding sizeInBits="1" />
+			</BooleanArgumentType>
+			<BooleanArgumentType name="CCSDS_Sec_Hdr_Flag_Type" zeroStringValue="NotPresent" oneStringValue="Present">
+				<UnitSet />
+				<IntegerDataEncoding sizeInBits="1" />
+			</BooleanArgumentType>
+			<IntegerArgumentType name="CCSDS_APID_Type" signed="false">
+				<UnitSet />
+				<IntegerDataEncoding sizeInBits="11" />
+			</IntegerArgumentType>
+			<EnumeratedArgumentType name="CCSDS_Group_Flags_Type">
+				<UnitSet />
+				<IntegerDataEncoding sizeInBits="2" />
+				<EnumerationList>
+					<Enumeration value="0" label="Continuation" />
+					<Enumeration value="1" label="First" />
+					<Enumeration value="2" label="Last" />
+					<Enumeration value="3" label="Standalone" />
+				</EnumerationList>
+			</EnumeratedArgumentType>
+			<IntegerArgumentType name="Packet_ID_Type" signed="false">
+				<UnitSet />
+				<IntegerDataEncoding sizeInBits="16" />
+			</IntegerArgumentType>
+			<IntegerArgumentType name="Battery_Type" signed="false">
+				<UnitSet />
+				<IntegerDataEncoding encoding="unsigned" sizeInBits="16" />
+				<ValidRangeSet>
+					<ValidRange minInclusive="1" maxInclusive="3" />
+				</ValidRangeSet>
+			</IntegerArgumentType>
+		</ArgumentTypeSet>
+		<MetaCommandSet>
+			<MetaCommand name="CCSDSPacket" abstract="true">
+				<ArgumentList>
+					<Argument argumentTypeRef="CCSDS_Version_Type" name="CCSDS_Version" />
+					<Argument argumentTypeRef="CCSDS_Type_Type" name="CCSDS_Type" />
+					<Argument argumentTypeRef="CCSDS_Sec_Hdr_Flag_Type" name="CCSDS_Sec_Hdr_Flag" />
+					<Argument argumentTypeRef="CCSDS_APID_Type" name="CCSDS_APID" />
+					<Argument argumentTypeRef="CCSDS_Group_Flags_Type" name="CCSDS_Group_Flags" />
+				</ArgumentList>
+				<CommandContainer name="CCSDSPacket">
+					<EntryList>
+						<ArgumentRefEntry argumentRef="CCSDS_Version" />
+						<ArgumentRefEntry argumentRef="CCSDS_Type" />
+						<ArgumentRefEntry argumentRef="CCSDS_Sec_Hdr_Flag" />
+						<ArgumentRefEntry argumentRef="CCSDS_APID" />
+						<ArgumentRefEntry argumentRef="CCSDS_Group_Flags" />
+						<!-- Final value is set by post-processor after the command is submitted. -->
+						<FixedValueEntry name="CCSDS_Source_Sequence_Count" binaryValue="0000" sizeInBits="14" />
+						<!-- Final value is set by post-processor after the command is submitted. -->
+						<FixedValueEntry name="CCSDS_Packet_Length" binaryValue="0000" sizeInBits="16" />
+					</EntryList>
+				</CommandContainer>
+			</MetaCommand>
+			<MetaCommand name="MyProjectPacket" abstract="true">
+				<BaseMetaCommand metaCommandRef="CCSDSPacket">
+					<ArgumentAssignmentList>
+						<ArgumentAssignment argumentName="CCSDS_Version" argumentValue="0" />
+						<ArgumentAssignment argumentName="CCSDS_Type" argumentValue="TC" />
+						<ArgumentAssignment argumentName="CCSDS_Sec_Hdr_Flag" argumentValue="NotPresent" />
+						<ArgumentAssignment argumentName="CCSDS_APID" argumentValue="101" />
+						<ArgumentAssignment argumentName="CCSDS_Group_Flags" argumentValue="Standalone" />
+					</ArgumentAssignmentList>
+				</BaseMetaCommand>
+				<ArgumentList>
+					<Argument argumentTypeRef="Packet_ID_Type" name="Packet_ID" />
+				</ArgumentList>
+				<CommandContainer name="MyProjectPacket">
+					<EntryList>
+						<ArgumentRefEntry argumentRef="Packet_ID" />
+					</EntryList>
+					<BaseContainer containerRef="CCSDSPacket" />
+				</CommandContainer>
+			</MetaCommand>
+			<MetaCommand name="Reboot">
+				<BaseMetaCommand metaCommandRef="MyProjectPacket">
+					<ArgumentAssignmentList>
+						<ArgumentAssignment argumentName="Packet_ID" argumentValue="1" />
+					</ArgumentAssignmentList>
+				</BaseMetaCommand>
+				<CommandContainer name="Reboot">
+					<EntryList />
+					<BaseContainer containerRef="MyProjectPacket" />
+				</CommandContainer>
+				<DefaultSignificance consequenceLevel="vital" />
+			</MetaCommand>
+			<MetaCommand name="SwitchVoltageOn" shortDescription="Switches a battery on">
+				<BaseMetaCommand metaCommandRef="MyProjectPacket">
+					<ArgumentAssignmentList>
+						<ArgumentAssignment argumentName="Packet_ID" argumentValue="2" />
+					</ArgumentAssignmentList>
+				</BaseMetaCommand>
+				<ArgumentList>
+					<Argument argumentTypeRef="Battery_Type" name="Battery" shortDescription="Number of the battery" />
+				</ArgumentList>
+				<CommandContainer name="SwitchVoltageOn">
+					<EntryList>
+						<ArgumentRefEntry argumentRef="Battery" />
+					</EntryList>
+					<BaseContainer containerRef="MyProjectPacket" />
+				</CommandContainer>
+			</MetaCommand>
+			<MetaCommand name="SwitchVoltageOff" shortDescription="Switches a battery off">
+				<BaseMetaCommand metaCommandRef="MyProjectPacket">
+					<ArgumentAssignmentList>
+						<ArgumentAssignment argumentName="Packet_ID" argumentValue="3" />
+					</ArgumentAssignmentList>
+				</BaseMetaCommand>
+				<ArgumentList>
+					<Argument argumentTypeRef="Battery_Type" name="Battery" shortDescription="Number of the battery" />
+				</ArgumentList>
+				<CommandContainer name="SwitchVoltageOff">
+					<EntryList>
+						<ArgumentRefEntry argumentRef="Battery" />
+					</EntryList>
+					<BaseContainer containerRef="MyProjectPacket" />
+				</CommandContainer>
+			</MetaCommand>
+		</MetaCommandSet>
+	</CommandMetaData>
+</SpaceSystem>


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #397

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->

Added simple node script, along with XTCE for testing, to exercise the `writeBufferWaterMark` in YAMCS.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
