### PR TITLE
Warn if default alarms are of a different type than a staticAlarm and…

### DIFF
--- a/src/providers/object-provider.js
+++ b/src/providers/object-provider.js
@@ -330,7 +330,8 @@ export default class YamcsObjectProvider {
         if (defaultAlarm?.staticAlarmRange) {
             return getLimitFromAlarmRange(defaultAlarm.staticAlarmRange);
         } else {
-            throw new Error(`Passed alarm has invalid object syntax for limit conversion`, defaultAlarm);
+            console.warn(`Passed alarm has invalid object syntax for limit conversion`, defaultAlarm);
+            return {};
         }
     }
 


### PR DESCRIPTION
… allow the app to continue

Closes #430 

### Describe your changes:
Change to warning if non- staticAlarms are configured, but allow the app to continue loading.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
