### PR TITLE
VIPEROMCT-494: realtime and historical providers should provide same datum format

### DIFF
--- a/.webpack/webpack.prod.js
+++ b/.webpack/webpack.prod.js
@@ -26,6 +26,6 @@ import common from './webpack.common.js';
 /** @type {import('webpack').Configuration} */
 const prodConfig = {
     mode: 'production',
-    devtool: 'eval-source-map'
+    devtool: 'source-map'
 }
 export default merge(common, prodConfig);

--- a/.webpack/webpack.prod.js
+++ b/.webpack/webpack.prod.js
@@ -26,6 +26,6 @@ import common from './webpack.common.js';
 /** @type {import('webpack').Configuration} */
 const prodConfig = {
     mode: 'production',
-    devtool: 'source-map'
+    devtool: 'eval-source-map'
 }
 export default merge(common, prodConfig);

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -240,9 +240,7 @@ export default class YamcsHistoricalTelemetryProvider {
 
         let data = [];
         results.forEach(result => {
-            const qualifiedName = qualifiedNameFromParameterId(result.id);
             let datum = {
-                id: qualifiedNameToId(qualifiedName),
                 timestamp: result[METADATA_TIME_KEY]
             };
             let value = getValue(result);

--- a/src/providers/historical-telemetry-provider.js
+++ b/src/providers/historical-telemetry-provider.js
@@ -19,15 +19,13 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-import { AGGREGATE_TYPE, OBJECT_TYPES, METADATA_TIME_KEY } from '../const.js';
+import { OBJECT_TYPES } from '../const.js';
 import {
     idToQualifiedName,
-    getValue,
     addLimitInformation,
     accumulateResults,
     yieldResults,
-    qualifiedNameFromParameterId,
-    qualifiedNameToId
+    convertYamcsToOpenMctDatum
 } from '../utils.js';
 import { commandToTelemetryDatum } from './commands.js';
 import { eventToTelemetryDatum } from './events.js';
@@ -240,19 +238,7 @@ export default class YamcsHistoricalTelemetryProvider {
 
         let data = [];
         results.forEach(result => {
-            let datum = {
-                timestamp: result[METADATA_TIME_KEY]
-            };
-            let value = getValue(result);
-
-            if (result.engValue.type !== AGGREGATE_TYPE) {
-                datum.value = value;
-            } else {
-                datum = {
-                    ...datum,
-                    ...value
-                };
-            }
+            const datum = convertYamcsToOpenMctDatum(result);
 
             addLimitInformation(result, datum);
             data.push(datum);

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,7 +19,7 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-import { AGGREGATE_TYPE, UNSUPPORTED_TYPE } from './const.js';
+import { AGGREGATE_TYPE, UNSUPPORTED_TYPE, METADATA_TIME_KEY } from './const.js';
 import limitConfig from "./limits-config.json";
 
 function idToQualifiedName(id) {
@@ -362,6 +362,24 @@ function flattenObjectArray(array, baseObj = {}) {
     }, baseObj);
 }
 
+function convertYamcsToOpenMctDatum(parameter, parentName) {
+    let datum = {
+        timestamp: parameter[METADATA_TIME_KEY]
+    };
+    const value = getValue(parameter, parentName);
+
+    if (parameter.engValue.type !== AGGREGATE_TYPE) {
+        datum.value = value;
+    } else {
+        datum = {
+            ...datum,
+            ...value
+        };
+    }
+
+    return datum;
+}
+
 export {
     buildStalenessResponseObject,
     getLimitFromAlarmRange,
@@ -373,5 +391,6 @@ export {
     accumulateResults,
     addLimitInformation,
     yieldResults,
-    getLimitOverrides
+    getLimitOverrides,
+    convertYamcsToOpenMctDatum
 };


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes VIPEROMCT-494

### Describe your changes:
* Do not include `id` in historical data
* Refactor realtime and historical providers to use same datum generator to prevent regression

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
