### PR TITLE
fix(#447): Return mdb override limits correctly on resize

### DIFF
--- a/src/providers/limit-provider.js
+++ b/src/providers/limit-provider.js
@@ -97,10 +97,8 @@ export default class LimitProvider {
     }
 
     getLimits(domainObject) {
-        const limits = domainObject.configuration.limits;
-
         return {
-            limits: () => Promise.resolve(limits)
+            limits: () => Promise.resolve(domainObject.configuration.limits)
         };
     }
 


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #447 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Fixes faulty scoping logic causing `openmct-yamcs` limit provider to send `undefined` limits

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
