### PR TITLE
Test for Performance Mode changes incorrectly changing sort order

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -11,8 +11,7 @@ yamcs/quickstart and openmct-yamcs (this one).
 3. `make all` in yamcs/quickstart
 4. `cd openmct-yamcs` to move out of yamcs/quickstart
 5. `npm install` in openmct-yamcs
-6. `npx playwright@1.45.0 install chromium` in openmct-yamcs
-7. Sanity test that yamcs is up with `npm run wait-for-yamcs` in openmct-yamcs
-8. `npm run test:getopensource`
-9. `npm run build:example` or `npm run build:example:master`
-10. `npm run test:e2e:watch`
+6. Sanity test that yamcs is up with `npm run wait-for-yamcs` in openmct-yamcs
+7. `npm run test:getopensource`
+8. `npm run build:example` or `npm run build:example:master`
+9. `npm run test:e2e:watch`

--- a/tests/e2e/yamcs/telemetryTables.e2e.spec.mjs
+++ b/tests/e2e/yamcs/telemetryTables.e2e.spec.mjs
@@ -53,7 +53,7 @@ test.describe("Telemetry Tables tests @yamcs", () => {
         await expect(page.getByRole('button', { name: 'SHOW LIMITED' })).toBeVisible();
     });
 
-    test.only('Telemetry tables when changing mode, will not change the sort order of the request', async ({ page }) => {
+    test('Telemetry tables when changing mode, will not change the sort order of the request', async ({ page }) => {
         const EVENTS_URL_STRING = 'events?';
 
         // Log all network requests

--- a/tests/e2e/yamcs/telemetryTables.e2e.spec.mjs
+++ b/tests/e2e/yamcs/telemetryTables.e2e.spec.mjs
@@ -53,7 +53,7 @@ test.describe("Telemetry Tables tests @yamcs", () => {
         await expect(page.getByRole('button', { name: 'SHOW LIMITED' })).toBeVisible();
     });
 
-    test('Telemetry tables when changing mode, will not change the sort order of the request', async ({ page }) => {
+    test.only('Telemetry tables when changing mode, will not change the sort order of the request', async ({ page }) => {
         const EVENTS_URL_STRING = 'events?';
 
         // Log all network requests

--- a/tests/e2e/yamcs/telemetryTables.e2e.spec.mjs
+++ b/tests/e2e/yamcs/telemetryTables.e2e.spec.mjs
@@ -56,11 +56,6 @@ test.describe("Telemetry Tables tests @yamcs", () => {
     test('Telemetry tables when changing mode, will not change the sort order of the request', async ({ page }) => {
         const EVENTS_URL_STRING = 'events?';
 
-        // Log all network requests
-        page.on('request', request => {
-            console.log('>>', request.method(), request.url());
-        });
-
         // Set up request interception before navigating
         const requestPromise = page.waitForRequest(request => request.url().includes(EVENTS_URL_STRING));
 

--- a/tests/e2e/yamcs/telemetryTables.e2e.spec.mjs
+++ b/tests/e2e/yamcs/telemetryTables.e2e.spec.mjs
@@ -53,4 +53,25 @@ test.describe("Telemetry Tables tests @yamcs", () => {
         await expect(page.getByRole('button', { name: 'SHOW LIMITED' })).toBeVisible();
     });
 
+    test('Telemetry tables when changing mode, will not change the sort order of the request', async ({ page }) => {
+        const EVENTS_URL_STRING = 'events?';
+
+        // Navigate to the Events table
+        await page.getByLabel('Navigate to Events yamcs.').click();
+
+        // Intercept and validate the request before clicking the button
+        const requestBefore = await page.waitForRequest(request => request.url().includes(EVENTS_URL_STRING) && request.url().includes('order=desc'));
+        expect(requestBefore.url()).toContain('order=desc');
+
+        // Find the mode switch button and click it, this will trigger a mutation on mutable objects configuration
+        await page.getByRole('button', { name: 'SHOW UNLIMITED' }).click();
+
+        // Intercept and validate the request after clicking the button
+        const requestAfter = await page.waitForRequest(request => request.url().includes(EVENTS_URL_STRING) && request.url().includes('order=desc'));
+        expect(requestAfter.url()).toContain('order=desc');
+
+        // Assert that the 'SHOW LIMITED' button is now visible
+        await expect(page.getByRole('button', { name: 'SHOW LIMITED' })).toBeVisible();
+    });
+
 });


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #468<!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
This test verifies that performance mode changes do not change the outgoing requests sort order. It's based on this fix in Open MCT: https://github.com/nasa/openmct/pull/7810


### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
