### PR TITLE
Add makefile and build currentbranch npm scripting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ test-results
 # Misc
 .DS_Store
 .vscode/settings.json
+
+quickstart/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,67 @@
+.PHONY: all clone-quickstart install-quickstart start-quickstart install-openmct-yamcs sanity-test build-example test-getopensource test-e2e clean
+
+all: clone-quickstart install-quickstart install-openmct-yamcs sanity-test build-example test-e2e
+
+start: clone-quickstart install-quickstart install-openmct-yamcs sanity-test build-example start-openmct
+
+clone-quickstart:
+	@echo "Running target: clone-quickstart"
+	@echo "Current working directory: $(shell pwd)"
+	if [ ! -d "quickstart" ]; then \
+		git clone https://github.com/yamcs/quickstart; \
+	else \
+		echo "Directory 'quickstart' already exists."; \
+	fi
+
+install-quickstart:
+	@echo "Running target: install-quickstart"
+	@cd quickstart/docker && $(MAKE) wait-for-sent
+
+start-quickstart:
+	@echo "Running target: start-quickstart"
+	@cd quickstart/docker && $(MAKE) all
+
+restart-quickstart:
+	@echo "Running target: reset-quickstart"
+	@cd quickstart/docker && $(MAKE) yamcs-down
+	@cd quickstart/docker && $(MAKE) simulator-down
+	@cd quickstart/docker && $(MAKE) all
+
+install-openmct-yamcs:
+	@echo "Running target: install-openmct-yamcs"
+	npm install
+
+sanity-test:
+	@echo "Running target: sanity-test"
+	npm run wait-for-yamcs
+
+build-example:
+	@echo "Running target: build-example"
+	@current_branch=$(shell git rev-parse --abbrev-ref HEAD)
+	@echo "Current branch of openmct-yamcs: $$current_branch checking if it exists in openmct repository"
+	@if git ls-remote --exit-code --heads https://github.com/nasa/openmct.git refs/heads/$$current_branch; then \
+		echo "Branch $$current_branch exists in openmct repository. Running build:example:currentbranch"; \
+		npm run build:example:currentbranch || { echo "Failed to run build:example:currentbranch"; exit 1; }; \
+	else \
+		echo "Branch $$current_branch does not exist in openmct repository. Running build:example:master"; \
+		npm run build:example:master || { echo "Failed to run build:example:master"; exit 1; }; \
+	fi
+
+start-openmct:
+	@echo "Running target: start-openmct"
+	npm start
+
+test-e2e:
+	@echo "Running target: test-e2e"
+	npm run test:getopensource
+	npm run test:e2e:quickstart:local
+
+clean:
+	@echo "Running target: clean"
+	npm run clean
+	if [ -d "quickstart" ]; then \
+		rm -rf quickstart; \
+		echo "Removed 'quickstart' directory."; \
+	else \
+		echo "Directory 'quickstart' does not exist."; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,13 @@ reset-quickstart:
 
 install-openmct-yamcs:
 	@echo "Running target: install-openmct-yamcs"
-	npm install || exit 1
+	npm install
 
 sanity-test:
 	@echo "Running target: sanity-test"
-	npm run wait-for-yamcs || exit 1
+	npm run wait-for-yamcs
 
-build-example:
+build-example: #This will run buid example based on the current branch of openmct-yamcs and fallback to master
 	@echo "Running target: build-example"
 	@current_branch=$(shell git rev-parse --abbrev-ref HEAD)
 	@echo "Current branch of openmct-yamcs: $$current_branch checking if it exists in openmct repository"
@@ -47,19 +47,16 @@ build-example:
 
 start-openmct:
 	@echo "Running target: start-openmct"
-	npm start || exit 1
+	npm start
 
 test-e2e:
 	@echo "Running target: test-e2e"
-	npm run test:getopensource || exit 1
-	npm run test:e2e:quickstart:local || exit 1
+	npm run test:getopensource
+	npm run test:e2e:quickstart:local
 
 clean:
 	@echo "Running target: clean"
-	npm run clean || exit 1
-	if [ -d "quickstart" ]; then \
-		rm -rf quickstart; \
-		echo "Removed 'quickstart' directory."; \
-	else \
-		echo "Directory 'quickstart' does not exist."; \
-	fi
+	npm run clean
+	echo "Ran npm run clean."
+	rm -rf quickstart
+	echo "Removed 'quickstart' directory."

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: all clone-quickstart install-quickstart start-quickstart install-openmct-yamcs sanity-test build-example test-getopensource test-e2e clean
 
-all: clone-quickstart install-quickstart install-openmct-yamcs sanity-test build-example test-e2e
+test-all: clone-quickstart install-quickstart install-openmct-yamcs sanity-test build-example test-e2e
 
-start: clone-quickstart install-quickstart install-openmct-yamcs sanity-test build-example start-openmct
+start-all: clone-quickstart install-quickstart install-openmct-yamcs sanity-test build-example start-openmct
 
 clone-quickstart:
 	@echo "Running target: clone-quickstart"
@@ -21,19 +21,17 @@ start-quickstart:
 	@echo "Running target: start-quickstart"
 	@cd quickstart/docker && $(MAKE) all
 
-restart-quickstart:
+reset-quickstart:
 	@echo "Running target: reset-quickstart"
-	@cd quickstart/docker && $(MAKE) yamcs-down
-	@cd quickstart/docker && $(MAKE) simulator-down
-	@cd quickstart/docker && $(MAKE) all
+	@cd quickstart/docker && $(MAKE) yamcs-simulator-restart
 
 install-openmct-yamcs:
 	@echo "Running target: install-openmct-yamcs"
-	npm install
+	npm install || exit 1
 
 sanity-test:
 	@echo "Running target: sanity-test"
-	npm run wait-for-yamcs
+	npm run wait-for-yamcs || exit 1
 
 build-example:
 	@echo "Running target: build-example"
@@ -49,16 +47,16 @@ build-example:
 
 start-openmct:
 	@echo "Running target: start-openmct"
-	npm start
+	npm start || exit 1
 
 test-e2e:
 	@echo "Running target: test-e2e"
-	npm run test:getopensource
-	npm run test:e2e:quickstart:local
+	npm run test:getopensource || exit 1
+	npm run test:e2e:quickstart:local || exit 1
 
 clean:
 	@echo "Running target: clean"
-	npm run clean
+	npm run clean || exit 1
 	if [ -d "quickstart" ]; then \
 		rm -rf quickstart; \
 		echo "Removed 'quickstart' directory."; \

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build:dist": "webpack --config ./.webpack/webpack.prod.mjs",
     "build:example": "npm install openmct@unstable --no-save",
     "build:example:master": "npm install nasa/openmct --no-save",
+    "build:example:currentbranch": "npm install nasa/openmct#$(git rev-parse --abbrev-ref HEAD) --no-save --verbose",
     "postbuild:example": "node check-optional-dependencies.mjs",
     "start": "npx webpack serve --config ./.webpack/webpack.dev.mjs",
     "start:coverage": "npx webpack serve --config ./.webpack/webpack.coverage.mjs",


### PR DESCRIPTION
Closes #480 

### Describe your changes:
Adds a Makefile to run `make all` on a `openmct-yamcs` PR and have it run the tests against the current branch's `openmct` branch or master if not found

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
